### PR TITLE
Sleight of hand combat redo alex l

### DIFF
--- a/play/PlayerRules/CharacterCreation/03_Feats.txt
+++ b/play/PlayerRules/CharacterCreation/03_Feats.txt
@@ -283,7 +283,7 @@ upgraded by making good decisions based on this skill, rather than by
 upgrading it with skill points.
 
 Sleight of hand: 
-Prerequisites:
+Prerequisites: DEX 6+
 Negate the pump of a shotgun, cocking of a revolver, or cycling of a bolt when
 performing another action besides the same (or firing).
 Reload DCs are 5% lower.

--- a/play/PlayerRules/CharacterCreation/03_Feats.txt
+++ b/play/PlayerRules/CharacterCreation/03_Feats.txt
@@ -284,7 +284,8 @@ upgrading it with skill points.
 
 Sleight of hand: 
 Prerequisites:
-Negate the pump of a shotgun, cocking of a revolver, or cycling of a bolt. 
+Negate the pump of a shotgun, cocking of a revolver, or cycling of a bolt when
+performing another action besides the same (or firing).
 Reload DCs are 5% lower.
 
 Snap Shot: 

--- a/play/PlayerRules/CharacterCreation/04_02_WeaponAttachments.txt
+++ b/play/PlayerRules/CharacterCreation/04_02_WeaponAttachments.txt
@@ -331,8 +331,8 @@ by 20% and Jam DCs are +20%
 
 Straight Pull bolt $460
 Allows the user a Straight-pull action to chamber a new round, increasing rate
-of fire. With DEX higher than 7, you can fire 1 round per Half-Action; 
-chambering a round is treated as a free action.
+of fire. With DEX higher than 7, you can negate 2 bolt-cycles per turn; 
+chambering a round is treated as a free action for those two cycles.
 
 Standalone Grenade Launcher $600
 A polymer and metal frame to mount an underbarrel grenade launcher. Allows use 

--- a/play/PlayerRules/CharacterCreation/04_02_WeaponAttachments.txt
+++ b/play/PlayerRules/CharacterCreation/04_02_WeaponAttachments.txt
@@ -331,8 +331,8 @@ by 20% and Jam DCs are +20%
 
 Straight Pull bolt $460
 Allows the user a Straight-pull action to chamber a new round, increasing rate
-of fire. With DEX higher than 7, you can negate 2 bolt-cycles per turn; 
-chambering a round is treated as a free action for those two cycles.
+of fire. You can negate 1 bolt-cycles per turn; chambering a round is treated
+as a free action for that cycle.
 
 Standalone Grenade Launcher $600
 A polymer and metal frame to mount an underbarrel grenade launcher. Allows use 


### PR DESCRIPTION
I highly suggest these 2 changes in order to keep all weapons from becoming, effectively, semi-automatic capable, for reasons of player choice, and weapon variety.

"Proposed balance change to "Sleight of hand" so that weapons without semi-automatic capability don't become identical to the same.
Allows the user to negate cocking of a weapon by performing another action first (aiming, moving, reloading, hacking, healing, etc.)
Alternative idea: Negate 1 bolt cycle per turn"