### PR TITLE
Restrict auto weapons from crit; Update Basic Rules.txt

### DIFF
--- a/play/PlayerRules/Basic Rules.txt
+++ b/play/PlayerRules/Basic Rules.txt
@@ -430,7 +430,8 @@ If your Luck is 5, on a roll of 90-1 through 90-5, the hit is considered a
 Critical hit, and deals an extra 10 damage. on a roll of 90-6 through 00-0, 
 the hit is considered an Extra-Critical hit, and deals an extra 20 damage. 
 Your Luck modifier ((Luck-5)*4) is subtracted from the lower bound of your 
-critical hit range.
+critical hit range. All weapons can critical hit except for Fully-Automatic
+weapons (weapons that shoot more than 1 bullet per half-action by default).
 Gun Jams:
 On a roll of 00-01, the weapon Jams, necessitating a weapon skill check, DC 60.
 When a player is defending against a hit, they roll Percentiles under their 


### PR DESCRIPTION
Changed the basic rules to restrict automatic weapons from critical hitting. Reflects the decision made in issue #77 