### PR TITLE
MH fix medic

### DIFF
--- a/play/PlayerRules/CharacterCreation/02_Classes.txt
+++ b/play/PlayerRules/CharacterCreation/02_Classes.txt
@@ -79,24 +79,34 @@ Miss Chance and +35 damage once per day for a heavy weapon attack.
 bodies), and put that knowledge to good use by supporting your team.
 Passives: Gain 5 skill in Anatomy, 5 skill in Pathology, and 10 skill in 
 medicine. Every level, you gain one skill in both of the "hippocratic" and "
-malpractice" skill trees. At the beggining of each encounter, you begin with 
-only half of your full count of nanites, but over the course of the battle, 
-you may gain up to 600 nanites max. 
+malpractice" skill trees. At level 1 you start with an arm mounted needle 
+launcher, handheld pathogen synthesizer, field dressing applicator and 
+a package of ten needles. You start each encounter with 200 adrenaline
+points and will need to keep track of adrenaline points, needles and 
+contagion points during a combat scenario.  
 Weapon Proficiencies: Pistols, Shotguns, SMGs
 Armour Proficiencies: Concealed, Recon, Light, Medium.
 Starting Wealth: $1700+100*Luck - 800
 Class Feats:
 ----------------------
-Scalpel jockey -
-You can slice with the best of them, mostly because there really isn''t any 
-competition for "Best frenzied medic" in these parts. 50% chance to stabilize 
-an organic who is crashing, or heal 25 health.
+Adrenaline Junkie - 
+You thrive on the stress of being shot at while trying to save someone's life.
+You know that every breath you take could be your last, and one errant twitch
+could mean the difference between sending your brother in arms to see his 
+friends and family or his ancestors. You love it. Your maximum adrenaline is 
+600 and you start each encounter with 240 adrenaline points instead of 200.
 |
 |
 |
 V
-You''ve learned to use more than just your scalpel and some gauze. 75% chance 
-success, or stabilize and heal 25 health, or just heal 50 health.
+Adrenaline Addict - 
+"Nothing in life is so exhilarating as to be shot at without result" ~ Winston Churchill
+Any time an enemy shoots at you and misses, gain 10 Adrenaline Points. 
+-----------------------
+The Harmisist - 
+Prerequisite: Level 10
+Learn an extra malpractice proceedure.
+
 
 "Engineer" - You solve problems. For insance, you know how to stop some mean 
 mutha-hubbard from tearin'' you and your team a structurally supurfluous new 

--- a/play/PlayerRules/CharacterCreation/07_Items.txt
+++ b/play/PlayerRules/CharacterCreation/07_Items.txt
@@ -41,7 +41,7 @@ Prevents the inhalation of noxious or toxic air-borne compunds. Reduce PER
 based rolls (including strike rolls) by 10.
 
 //===================
-//consuables
+//consumables
 //===================
 
 MarkAll(tm) permanent marking pen. $2
@@ -64,6 +64,10 @@ Restores 2d10 + 20 nanites.
 Security Spike: $100
 +20 to a hack check on a door with a physical access panel. DC 30 to place. 
 Once hacked the door can be controlled remotely.
+
+Medic Needle Pack: $60
+Contains 10 needles suitable for use with several malpractice proceedures.
+Not recomended for medicianal use. 
 
 Single Use door brute-forcer $120:
 Hacks through the encryption on a door (up to 75 DC) and opens it.

--- a/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
+++ b/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
@@ -150,9 +150,9 @@ Adrenaline Cost: 340
 Contagion Cost: 3
 Duration: 	engagement
 Range:		Payload (use in combination with other powers)
-Effect:		Target enters a zombie-like state as nanites enter their 
+Effect:		Target enters a zombie-like state as the modified contagion enter their 
 bloodstream and use protien targeting to bind to the target's central nervous 
-system. The nanites emulate rare parisites that vary neurotransmitters and
+system. The contagion emulate rare parisites that vary neurotransmitters and
 stimulate axion impulses. The end result is that the Doc receives rudimentary
 control over the target. Use of CNS Override protocols is experimental, prone
 to failure, and very illegal in most sectors. CNS Override only affects 
@@ -398,7 +398,7 @@ Action:			2 Full Actions
 Effect:			Stands for Persistant Emergent Generalists, a type of surgical 
 nanobot that stays in the patient's bloodstream and continues to administer 
 care over an extended period of time. Effect lasts for 10 turns and heals 10 
-health every turn. DC 60 to hack. If nanites are hacked, deals damage instead. 
+health every turn. DC 60 to hack. If nanobots are hacked, deals damage instead. 
 PEGs are easily detectable by tech scanning technologies or spells. PEGs cannot
  heal a patient over their maximum health.
 
@@ -410,7 +410,7 @@ Action:			1 Full Action
 Effect:			Stands for Persistant Emergent Generalists, a type of surgical 
 nanobot that stays in the patient's bloodstream and continues to administer 
 care over an extended period of time. Effect lasts for 5 turns and heals 20 
-health every turn. DC 130 to hack. If nanites are hacked, deals damage instead. 
+health every turn. DC 130 to hack. If nanobots are hacked, deals damage instead. 
 PEGs are easily detectable by tech scanning technologies or spells. PEGs cannot 
 heal a patient over their maximum health.
 
@@ -490,7 +490,7 @@ Contagion Reward:		n
 Range:			6m circle, doc is the origin
 Action:			Full Action
 Effect:			Every biologic patient in range has one wound healed by 40 
-points. The doc gets n nanites back where n is the number of patients healed.
+points. The doc gets n adrenaline points back where n is the number of patients healed.
 Heals allies and enemies. The doc gets a -200 to stealth rolls when performing
 this proceedure.
 

--- a/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
+++ b/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
@@ -2,14 +2,30 @@ Medics have the skills and tools to perform certain proceedures.
 
 
 Contagions:
+Some of the more ... questionable... talents of the medic require the use of 
+mutated pathogens. The medic's tools can mutate existing biologic material
+to produce certain (usually harmfull) traits. Contagions are not stored between
+conflicts and die at the end of an engagement.
 
+Adrenaline:
+Not to be confused with the feat by the same name. As a Medic fights, their
+adrenaline levels rise. Some abilities require a certain amount of adrenaline
+to perform in combat scenarios. A medic cannot have more than 500 
+adrenaline points at any time. While medics are able to calm down between
+engagements, they don't ever really relax all the way in a combat zone. 
+The net effect is that a medic starts every engagement with 100 adrenaline
+points. 
+
+Needles:
+Some abilities require the expendature of large, spikey needles. They can
+be purchased at most medical centers and some weapons stores.
 
 =================================
 =====	Malpractice Tree	=====
 =================================
 
 /////	Medical Emergency
-Nanite Cost:40
+Adrenaline Cost:40
 Duration: 	Free Action
 Range:		Self
 Effect:		Increase move speed to 12m per action
@@ -19,7 +35,8 @@ they have more important things to worry about. Cannot be used to move
 more than 36m per turn.
 
 /////	Nanite Spike
-Nanite Cost:30
+Adrenaline Cost:30
+Needle Cost:	1
 Duration: 	Standard Action
 Range:		40m
 Effect:		10 % chance to miss. Deal 52 piercing damage.
@@ -27,7 +44,8 @@ If target has no shield left and is still alive, apply a
 poison payload of your choice.
 
 /////	Fast Spike
-Nanite Cost:30
+Adrenaline Cost:30
+Needle Cost:	1
 Duration: 	Half Action
 Range:		40m
 Effect:		16 % chance to miss. Deal 52 piercing damage.
@@ -35,7 +53,8 @@ If target has no shield left and is still alive, apply a
 poison payload of your choice.
 
 /////	Multi Spikes
-Nanite Cost:90
+Adrenaline Cost: 40
+Needle Cost: 3
 Duration: 	Standard Action
 Range:		30m
 Effect:		You launch off three nanite spikes in quick succession using both
@@ -44,14 +63,16 @@ launch at. Each spike that hits deals 52 piercing damage. If target has no
 shield left and is still alive, apply a poison payload of your choice.
 
 /////	Peircing Spike
-Nanite Cost:35
+Adrenaline Cost:35
+Needle Cost: 1
 Duration: 	Standard Action
 Range:		45m
 Effect:		10 % chance to miss. Deal 42 piercing damage.
 ignores sheilds and balistic armor. Apply a poison payload of your choice.
 
 /////	Poison: Mild Halucinogen
-Nanite Cost:20
+Adrenaline Cost:20
+Contagion Cost: 1
 Duration: 	5 turns
 Range:		Payload (use in combination with other powers)
 Effect:		Target must pass a DC 70 Will check. If they fail, 
@@ -66,7 +87,8 @@ watering the grass dilligently
 Halucinogens only affects biologic targets.
 
 /////	Poison: Depressant
-Nanite Cost:30
+Adrenaline Cost:30
+Contagion Cost: 1
 Duration: 	engagement
 Range:		Payload (use in combination with other powers)
 Effect:		Target must pass a DC 70 Will check. If they fail, target
@@ -76,14 +98,15 @@ deploment powers that otherwise wouldn't. +5m radius area of effect.
 Depressant only affects biologic targets.
 
 /////	Quarentine
-Nanite Cost:120
+Adrenaline Cost:120
 Duration: 	Half Action
 Range:		2 to 8m radius within 30m at your discression
 Effect:		All enemies within the the radius of effect cannot leave 
 the area of effect. Effect persists for 8 turns.
 
 /////	Poison: Potent Halucinogen
-Nanite Cost: 50
+Adrenaline Cost: 50
+Contagion Cost: 2
 Duration: 	10 turns
 Range:		Payload (use in combination with other powers)
 Effect:		Target must pass a DC 150 Will check. If they fail, 
@@ -103,7 +126,8 @@ pursuit of cake. The target has the worst munchies.
 Halucinogens only affects biologic targets.
 
 /////	Poison: Fentanyl Derivative
-Nanite Cost:60
+Adrenaline Cost: 60
+Contagion Cost: 1
 Duration: 	engagement
 Range:		Payload (use in combination with other powers)
 Effect:		Target must pass a DC 60 Shock check for every action they take over
@@ -115,14 +139,15 @@ on biologic targets.
 
 
 /////	Breakout
-Nanite Cost:60
+Adrenaline Cost: 60
 Duration: 	Standard Action
 Range:		15m to 20m radius, with Doc as the center
 Effect:		Apply a payload of poison of your choosing to every target in range.
 Targets with gas masks are immune. Allies are targeted as well.
 
 /////	Poison: CNS Override
-Nanite Cost:400
+Adrenaline Cost: 340
+Contagion Cost: 3
 Duration: 	engagement
 Range:		Payload (use in combination with other powers)
 Effect:		Target enters a zombie-like state as nanites enter their 
@@ -134,7 +159,8 @@ to failure, and very illegal in most sectors. CNS Override only affects
 biologic targets.
 
 /////	Poison:	PAX
-Nanite Cost:100
+Adrenaline Cost: 80
+Contagion Cost: 2
 Duration: 	1 Day
 Range:		Payload (use in combination with other powers)
 Effect:		A target exposed to the PAX strain must pass a DC 240 Will save.
@@ -152,14 +178,15 @@ to kill and eat any living target until it dies of overconsumption or exaustion.
 PAX only affects biologic targets.
 
 /////	Epidemic
-Nanite Cost:80
+Adrenaline Cost:80
 Duration: 	Standard Action
 Range:		30m to 35m radius, with Doc as the center
 Effect:		Apply a payload of poison of your choosing to every target in range.
 Targets with gas masks are immune. Allies are targeted as well.
 
 /////	Poison:	NF-34
-Nanite Cost:80
+Adrenaline Cost: 80
+Contagion Cost: 1
 Duration: 	20 turns
 Range:		Payload (use in combination with other powers)
 Effect:		The biologic agent eats away at the target's flesh and biologic 
@@ -171,7 +198,7 @@ wouldn't. Use of biologic weapons are severely frowned upon in most civilized
 regions of space.
 
 /////	Pasteurize
-Nanite Cost:60
+Adrenaline Cost: 60
 Duration: 	Standard Action
 Range:		35m
 Effect:		The Doc uses their nanites to focus microwaves to steralize a 
@@ -182,23 +209,28 @@ well. Ongoing damage takes effect the first round that this attack hits, at
 the end of the target's turn. Pasteurize burns do not stack on each other. 
 
 /////	Poison: Thiopental Derivative
-Nanite Cost:15
+Contagion Cost: 1
 Duration: 	Standard Action
 Range:		Payload (use in combination with other powers)
-Effect:		Truth serum. Principle uses are for role playing. While any 
-character could procure similar substances as a role-playing item for 1EP
-a piece, the value of this trick is that it's free, almost unlimited and 
-you don't need to worry about smuggling it anywhere.
+Effect:		Truth serum. Principle uses are for noncombat situations. While any 
+character could procure similar substances as a role-playing item for about $60 
+worth of chemistry suplies and a chemistry check of DC 80 a piece, the value of 
+this trick is that it's free, almost unlimited and you don't need to worry about 
+smuggling it anywhere.
 
 /////	Transmission Vector
-Nanite Cost:60
+Adrenaline Cost:60
+Needle Cost: 1
 Duration: 	Standard Action
 Range:		5m radius centered at a point up to 30m from the Doc
-Effect:		Targets without gas masks have the poison payload of your choice
-applied to them.
+Effect:		You add an aerator to the end of your needle and launch it not at 
+one target in particular, but among the frey hoping to hit multiple targets.
+Targets without gas masks have the poison payload of your choice applied to 
+them.
 
 /////	Poison:	NF-40
-Nanite Cost:60
+Adrenaline Cost: 60
+Contagion Cost: 1
 Duration: 	two weeks
 Range:		Payload (use in combination with other powers)
 Effect:		The biologic agent eats away at the target's flesh and biologic 
@@ -210,7 +242,8 @@ wouldn't. Use of biologic weapons are severely frowned upon in most civilized
 regions of space.
 
 /////	Poison:	Lethal Toxin
-Nanite Cost:60
+Adrenaline Cost: 60
+Contagion Cost: 1
 Duration: 	almost instantaneous
 Range:		Payload (use in combination with other powers)
 Effect:		A biologic target aflicted with this poison takes 180 damage that 
@@ -218,23 +251,26 @@ ignores shields, silences the target and prevents them from casting nanite
 spells for 10 turns if they survive.
 
 /////	Plague
-Nanite Cost: 250
+Adrenaline Cost: 250
+Neelde Cost: 2
 Duration: 	1 day
 Range:		40m
 Effect:		The target has the poison payload of your choice applied to them.
 Any time another biologic target (friend or foe) comes within 8m of a target 
 infected with plague that new target gets infected too. This effect is 
-recoursive without limit. 
+recoursive without limit, but a target that has made a save against the 
+payload delivered by this proceedure is inoculated from subsequent recoursions
+of this proceedure.
 
 /////	Nanite Push
-Nanite Cost: 40
+Adrenaline Cost: 40
 Duration: 	Standard Action
 Range:		20m
 Effect:		Imparts enough force on a target or object to shift a 300lb 
 target 10m away by 1m.
 
 /////	Mild Phenethylamine Agonist
-Nanite Cost:60
+Adrenaline Cost:60
 Duration: 	Half Action
 Range:		Applies to the Doc only
 Effect:		For 3 turns, the doc gets a -28% to miss with guns, grenades, 
@@ -242,7 +278,7 @@ spells, and melee weapons. They also get a +30 to reload and a +10% chance to
 crit.
 
 /////	Free Running
-Nanite Cost:60
+Adrenaline Cost:60
 Duration: 	Standard Action
 Range:		5m radius centered at a point up to 30m from the Doc
 Effect:		Your nanites form microscopic bonds with any solid surface allowing 
@@ -251,7 +287,7 @@ weight. The proceedure for doing this without blowing up one's heart or leaving
 one's spine behind takes more training than the average soldier receives. 
 
 /////	Dex-10
-Nanite Cost:60
+Adrenaline Cost:60
 Duration: 	half action
 Range:		Doc only
 Effect:		Your move speed increases by 4m per full action, with an absolute
@@ -259,14 +295,14 @@ maximum of 13m per action. Dex-10 lasts for one engagement. A Doc cannot have
 more than one dose of DEX at a time.
 
 /////	Nanite Wave
-Nanite Cost:60
+Adrenaline Cost:60
 Duration: 	Standard Action
 Range:		A 45 degree angle centered on the Doc and extending out 15m
 Effect:		Biologic targets in the area of effect without gas masks have the
  oison payload of your choice applied to them.
 
 /////	Illegal Penethylamine Agonist
-Nanite Cost:60
+Adrenaline Cost:60
 Duration: 	Half Action
 Range:		Applies to the Doc only
 Effect:		For 3 turns, the doc gets a -46% to miss with guns, grenades, 
@@ -274,7 +310,7 @@ spells, and melee weapons. They also get a +60 to reload and a +10% chance to
 crit.
 
 /////	Dex-11
-Nanite Cost:80
+Adrenaline Cost:80
 Duration: 	half action
 Range:		Doc only
 Effect:		Your move speed increases by 6m per full action, with an absolute
@@ -282,7 +318,7 @@ maximum of 17m per action. Dex-11 lasts for one engagement. A Doc cannot have
 more than one dose of DEX at a time.
 
 /////	The Good Stuff
-Nanite Cost:500
+Adrenaline Cost:500
 Duration: 	Standard Action
 Range:		Effects apply only to the Doc
 Effect:		This is a fully customized brew specially grown to bond with your

--- a/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
+++ b/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
@@ -583,8 +583,8 @@ the engagement. This trick works on any race of ally.
 Adrenaline Reward:	n/4
 Range:			Touch
 Action:			Free Action
-Effect:			Transfer n number of nanites from the Doc to the patient. If
-This trick is used on another doctor, no nanites are earned. 
+Effect:			Transfer n number of Adrenaline points from the Doc to the 
+patient. If This trick is used on another doctor, no adrenaline points are earned. 
 
 /////	Illegal Steroid
 Adrenaline Reward:	40

--- a/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
+++ b/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
@@ -270,7 +270,8 @@ Effect:		Imparts enough force on a target or object to shift a 300lb
 target 10m away by 1m.
 
 /////	Mild Phenethylamine Agonist
-Adrenaline Cost:60
+Adrenaline Cost: 60
+Contagion Cost: 1
 Duration: 	Half Action
 Range:		Applies to the Doc only
 Effect:		For 3 turns, the doc gets a -28% to miss with guns, grenades, 
@@ -278,7 +279,7 @@ spells, and melee weapons. They also get a +30 to reload and a +10% chance to
 crit.
 
 /////	Free Running
-Adrenaline Cost:60
+Adrenaline Cost: 60
 Duration: 	Standard Action
 Range:		5m radius centered at a point up to 30m from the Doc
 Effect:		Your nanites form microscopic bonds with any solid surface allowing 
@@ -287,7 +288,8 @@ weight. The proceedure for doing this without blowing up one's heart or leaving
 one's spine behind takes more training than the average soldier receives. 
 
 /////	Dex-10
-Adrenaline Cost:60
+Adrenaline Cost: 60
+Contagion Cost: 1
 Duration: 	half action
 Range:		Doc only
 Effect:		Your move speed increases by 4m per full action, with an absolute
@@ -295,14 +297,15 @@ maximum of 13m per action. Dex-10 lasts for one engagement. A Doc cannot have
 more than one dose of DEX at a time.
 
 /////	Nanite Wave
-Adrenaline Cost:60
+Adrenaline Cost: 60
 Duration: 	Standard Action
 Range:		A 45 degree angle centered on the Doc and extending out 15m
 Effect:		Biologic targets in the area of effect without gas masks have the
  oison payload of your choice applied to them.
 
 /////	Illegal Penethylamine Agonist
-Adrenaline Cost:60
+Adrenaline Cost: 60
+Contagion Cost: 1
 Duration: 	Half Action
 Range:		Applies to the Doc only
 Effect:		For 3 turns, the doc gets a -46% to miss with guns, grenades, 
@@ -310,7 +313,8 @@ spells, and melee weapons. They also get a +60 to reload and a +10% chance to
 crit.
 
 /////	Dex-11
-Adrenaline Cost:80
+Adrenaline Cost: 80
+Contagion Cost: 1
 Duration: 	half action
 Range:		Doc only
 Effect:		Your move speed increases by 6m per full action, with an absolute
@@ -318,12 +322,13 @@ maximum of 17m per action. Dex-11 lasts for one engagement. A Doc cannot have
 more than one dose of DEX at a time.
 
 /////	The Good Stuff
-Adrenaline Cost:500
+Adrenaline Cost:380
+Contagion Cost: 3
 Duration: 	Standard Action
 Range:		Effects apply only to the Doc
 Effect:		This is a fully customized brew specially grown to bond with your
 personal biochemestry. The effect lasts for 8 turns. You gain:
-*	-20% to miss with melee, guns, thrown weapons, or spells
+*	-20% to miss with melee, guns, thrown weapons, or Proceedures
 *	an additional half action per turn
 *	an additional temporary 40 hp
 *	an additional 2m move speed per action. 
@@ -333,14 +338,16 @@ personal biochemestry. The effect lasts for 8 turns. You gain:
 =================================
 
 /////	Patch Em Up
-Nanite Reward:	40
+Adrenaline Reward:	40
+Contagion Reward: 	1
 Range:			Touch
 Action:			Half Action
 Effect:			One of the target's wounds are healed. This trick only works
  on biologic patients.
 
 /////	Defib
-Nanite Reward:	80
+Adrenaline Reward:	80
+Contagion Reward:		2
 Range:			Touch
 Action:			Half Action
 Effect:			Only usable on an person that is bleeding out. The person is
@@ -349,7 +356,8 @@ then heal them as a separate action. This trick only works on biologic
 patients.
 
 /////	Rub Some Dirt In It
-Nanite Reward:	30*n
+Adrenaline Reward:	30*n
+Contagion Reward:		n (max 3)
 Range:			Touch
 Action:			Half Action
 Effect:			The patient is healed by the Doc's heal roll / n, where n is 
@@ -357,21 +365,22 @@ the number of wounds that the patient has. This trick only works on biologic
 patients.
 
 /////	Remote Surgery
-Nanite Reward:	20
+Adrenaline Reward:	20
 Range:			20m
 Action:			Full Action
 Effect:			One of the patient's wounds are healed for half of the Doc's 
 heal roll. This trick only works on biologic patients.
 
 /////	Remote Defib
-Nanite Reward:	65
+Adrenaline Reward:	65
 Range:			25m
 Action:			Full Action
 Effect:			The patient is no longer bleeding out and has 20 health. This 
 trick only works on biologic patients.
 
 /////	Cortical Stimulator
-Nanite Reward:	200
+Adrenaline Reward:	200
+Contagion Reward:		4
 Range:			Touch
 Action:			2 Full Actions
 Effect:			Can only be used on a biologic patient who's head is intact who
@@ -382,7 +391,8 @@ feat 'Back from the Dead'. Characters with the 'Back From the Dead' feat have a
  revived by Cortical Stimulator.
 
 /////	P.E.G.s
-Nanite Reward:	40
+Adrenaline Reward:	40
+Contagion Reward:		1
 Range:			Touch
 Action:			2 Full Actions
 Effect:			Stands for Persistant Emergent Generalists, a type of surgical 
@@ -393,16 +403,19 @@ PEGs are easily detectable by tech scanning technologies or spells. PEGs cannot
  heal a patient over their maximum health.
 
 /////	Improved P.E.G.s
-Nanite Reward:	50
+Adrenaline Reward:	50
+Contagion Reward:		2
 Range:			Touch
 Action:			1 Full Action
 Effect:			Stands for Persistant Emergent Generalists, a type of surgical 
 nanobot that stays in the patient's bloodstream and continues to administer 
 care over an extended period of time. Effect lasts for 5 turns and heals 20 
-health every turn. DC 130 to hack. If nanites are hacked, deals damage instead. PEGs are easily detectable by tech scanning technologies or spells. PEGs cannot heal a patient over their maximum health.
+health every turn. DC 130 to hack. If nanites are hacked, deals damage instead. 
+PEGs are easily detectable by tech scanning technologies or spells. PEGs cannot 
+heal a patient over their maximum health.
 
 /////	Mild Stim
-Nanite Reward:	15
+Adrenaline Reward:	15
 Range:			Touch
 Action:			Half Action
 Effect:			For 4 turns, the patient moves 1m more per action and gets a 
@@ -411,7 +424,7 @@ with melee weapons. Increasing the dosage does not increase the effects. This
 trick only works on biologic patients.
 
 /////	Triage
-Nanite Reward:	5
+Adrenaline Reward:	5
 Range:			10m
 Action:			Half Action
 Effect:			You take a brief second to scan an enemy using your diagnostic
@@ -420,7 +433,8 @@ his wounds and remaining health. You also are aware of any special effects or
 obvious chemical agents he is being affected by.
 
 /////	Purge
-Nanite Reward:	40
+Adrenaline Reward:	40
+Contagion Reward: 	3
 Range:			Touch
 Action:			Half Action
 Effect:			That's right... let it all out... Tastes a special kind of 
@@ -432,7 +446,7 @@ ongoing internal CS burns, depressants, and paralytics other than physical
 impact. This proceedure only works on biologic targets.
 
 /////	Mild Analgesic
-Nanite Reward:	10
+Adrenaline Reward:	10
 Range:			Touch
 Action:			Half Action
 Effect:			You shoot your ally with a mild pain releiver, not enough to
@@ -444,7 +458,7 @@ side effects like irational happiness, lack of focus, addiction and cardiac
 arrest.
 
 /////	Strong Analgesic
-Nanite Reward:	22
+Adrenaline Reward:	22
 Range:			Touch
 Action:			Half Action
 Effect:			You shoot your ally with a strong pain releiver, not enough to
@@ -456,7 +470,7 @@ side effects like irational happiness, lack of focus, addiction and cardiac
 arrest.
 
 /////	Illicit Analgesic
-Nanite Reward:	34
+Adrenaline Reward:	34
 Range:			Touch
 Action:			Half Action
 Effect:			The ECSC really shouldn't find out that you've been stocking up
@@ -471,7 +485,8 @@ blind or deaf or both at the GM's discression. If Intelligence drops below 1 at
 any time during the engagement, the patient suffers brain death.
 
 /////	Healing Nova
-Nanite Reward:	30 * n
+Adrenaline Reward:	30 * n
+Contagion Reward:		n
 Range:			6m circle, doc is the origin
 Action:			Full Action
 Effect:			Every biologic patient in range has one wound healed by 40 
@@ -480,7 +495,8 @@ Heals allies and enemies. The doc gets a -200 to stealth rolls when performing
 this proceedure.
 
 /////	Improved Healing Nova
-Nanite Reward:	30 * n
+Adrenaline Reward:	30 * n
+Contagion Reward:		n
 Range:			6m circle, doc is the origin
 Action:			Full Action
 Effect:			Every biologic patient in range has Two wounds healed by 40 
@@ -489,7 +505,7 @@ Only Heals Allies. The doc gets a -50 to stealth rolls when performing this
 proceedure.
 
 /////	5-HT Inhibiter
-Nanite Reward:	10
+Adrenaline Reward:	10
 Range:			Touch
 Action:			Half Action
 Effect:			your ally gets a 10% bonus to perception checks, and 5% bonuses
@@ -498,7 +514,7 @@ time one of those effects are triggered. Only works on biologic patients. a
 patient cannot have more than one dose of 5-HT Inhibiter. 
 
 /////	Dex-7
-Nanite Reward:	20
+Adrenaline Reward:	20
 Range:			Touch
 Action:			Half Action
 Effect:			For an engagement, an ally moves 3m per action more. Loosely 
@@ -508,7 +524,7 @@ receive more than one dose of Dex per engagement. Only works on biologic
 allies.
 
 /////	Combat Stim
-Nanite Reward:	25
+Adrenaline Reward:	25
 Range:			Touch
 Action:			Half Action
 Effect:			For 5 turns, the patient moves 2m more per action and gets a 
@@ -517,7 +533,7 @@ with melee weapons. Increasing the dosage does not increase the effects. This
 trick only works on biologic patients. 
 
 /////	Oni
-Nanite Reward:	25
+Adrenaline Reward:	25
 Range:			Touch
 Action:			Half Action
 Effect:			Phentermine derivative manufactured by Sakai Corp on kimon in
@@ -525,28 +541,29 @@ sector 5. Central nervous system stimulant. Patient gets a +20 to reflex rolls
 and a +20 to initiative (turn order) for 5 turns. Oni doesn't give more than one
 turn per round. May only be used on biologic patients. Cannot be used on a 
 patient more than once lest they get mortally constipated, impotent, or their heart 
-explodes. (note: these are the effects of a Phentermine overdose) 
+explodes. (note: these are the actual effects of a Phentermine overdose) 
 
 /////	Illegal Stim
-Nanite Reward:	40
+Adrenaline Reward:	40
 Range:			Touch
 Action:			Half Action
 Effect:			For 5 turns, the patient moves 3m more per action (max 13), gets 
 a -14% to miss with guns and a +30 to rolls to parkour around obsticles. As a 
 side effect, the target suffers a +25% to miss with melee weapons and a -15 to
-charisma rules from being jittery. Increasing the dosage does not increase the
+charisma rolls from being jittery. Increasing the dosage does not increase the
 effects. This trick only works on biologic patients.  
 
 /////	Sense Heartbeat
-Nanite Reward:	20*n
+Adrenaline Reward:	20*n
 Range:			20m radius centered on the Doc
 Action:			Half Action
-Effect:			Reveal central nervous systems within a 20m radius of the Doc.
+Effect:			Reveal active central nervous systems within a 20m radius of the Doc.
 Every target revealed by Sense Heartbeat that is comminicated to an ally and is
-then defeated grants the Doc 20 nanites. 
+then defeated grants the Doc 20 nanites. This ability may be sustained for 5 
+adrenaline per turn as a free action.
 
 /////	Mild Steroid
-Nanite Reward:	15
+Adrenaline Reward:	15
 Range:			Touch
 Action:			Half Action
 Effect:			The patient deals an extra 2*(patient's strength) damage with
@@ -556,21 +573,21 @@ duration of the effect. This trick only works on biologic patients. This effect
 lasts for 4 turns.
 
 /////	Preventative Medicine
-Nanite Reward:	20
+Adrenaline Reward:	20
 Range:			Touch
 Action:			Half Action
 Effect:			Target gets a 30 point capacitive shield for the duration of 
 the engagement. This trick works on any race of ally. 
 
 /////	Nanite Restore
-Nanite Reward:	n/4
+Adrenaline Reward:	n/4
 Range:			Touch
 Action:			Free Action
 Effect:			Transfer n number of nanites from the Doc to the patient. If
 This trick is used on another doctor, no nanites are earned. 
 
 /////	Illegal Steroid
-Nanite Reward:	40
+Adrenaline Reward:	40
 Range:			Touch
 Action:			Half Action
 Effect:			The patient deals an extra 3*(patient's strength) damage with

--- a/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
+++ b/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
@@ -195,17 +195,6 @@ exposed biology are affected by this even if a deployment method says they
 wouldn't. Use of biologic weapons are severely frowned upon in most civilized 
 regions of space.
 
-/////	Pasteurize
-Adrenaline Cost: 60
-Duration: 	Standard Action
-Range:		35m
-Effect:		The Doc uses their nanites to focus microwaves to steralize a 
-target that they can see. 15% chance to miss. Target takes 20 burn damage,
-and 20 ongoing burn damage for 5 turns unless cooled somehow. Ignore Shields,
-Do not ignore armor. If this attack hits armor, ongoing damage is reduced as 
-well. Ongoing damage takes effect the first round that this attack hits, at
-the end of the target's turn. Pasteurize burns do not stack on each other. 
-
 /////	Biopsy
 Adrenaline Cost: 40
 Needle Cost:		1

--- a/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
+++ b/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
@@ -1,3 +1,9 @@
+Medics have the skills and tools to perform certain proceedures.
+
+
+Contagions:
+
+
 =================================
 =====	Malpractice Tree	=====
 =================================

--- a/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
+++ b/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
@@ -34,7 +34,7 @@ in a medical emergency, the Doc suffers a +28% chance to miss, 'cause
 they have more important things to worry about. Cannot be used to move
 more than 36m per turn.
 
-/////	Nanite Spike
+/////	Harmasist Spike
 Adrenaline Cost:30
 Needle Cost:	1
 Duration: 	Standard Action
@@ -57,7 +57,7 @@ Adrenaline Cost: 40
 Needle Cost: 3
 Duration: 	Standard Action
 Range:		30m
-Effect:		You launch off three nanite spikes in quick succession using both
+Effect:		You launch off three harmasist spikes in quick succession using both
 hands. Each has an 18 % chance to miss. You may pick up to three targets to 
 launch at. Each spike that hits deals 52 piercing damage. If target has no 
 shield left and is still alive, apply a poison payload of your choice.
@@ -500,9 +500,9 @@ Contagion Reward:		n
 Range:			6m circle, doc is the origin
 Action:			Full Action
 Effect:			Every biologic patient in range has Two wounds healed by 40 
-points. The doc gets n nanites back where n is the number of wounds healed.
-Only Heals Allies. The doc gets a -50 to stealth rolls when performing this
-proceedure.
+points. The doc gets n adrenaline points back where n is the number of 
+wounds healed. Only Heals Allies. The doc gets a -50 to stealth rolls when 
+performing this proceedure.
 
 /////	5-HT Inhibiter
 Adrenaline Reward:	10
@@ -559,8 +559,8 @@ Range:			20m radius centered on the Doc
 Action:			Half Action
 Effect:			Reveal active central nervous systems within a 20m radius of the Doc.
 Every target revealed by Sense Heartbeat that is comminicated to an ally and is
-then defeated grants the Doc 20 nanites. This ability may be sustained for 5 
-adrenaline per turn as a free action.
+then defeated grants the Doc 20 adrenaline points. This ability may be 
+sustained for 5 adrenaline per turn as a free action.
 
 /////	Mild Steroid
 Adrenaline Reward:	15

--- a/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
+++ b/play/PlayerRules/CharacterCreation/Class-Specific Documentation/Medic Proceedures.txt
@@ -136,8 +136,6 @@ canceled and they lose that action. If they fail three checks they pass out.
 if they pass out, they must pass a shock check of 120 to wake up. Only works
 on biologic targets.
 
-
-
 /////	Breakout
 Adrenaline Cost: 60
 Duration: 	Standard Action
@@ -207,6 +205,19 @@ and 20 ongoing burn damage for 5 turns unless cooled somehow. Ignore Shields,
 Do not ignore armor. If this attack hits armor, ongoing damage is reduced as 
 well. Ongoing damage takes effect the first round that this attack hits, at
 the end of the target's turn. Pasteurize burns do not stack on each other. 
+
+/////	Biopsy
+Adrenaline Cost: 40
+Needle Cost:		1
+Contagion Reward: 4
+Duration: Half Action
+Range: Touch
+Effect: You need more pathogens, but your teammates aren't sharing. Perhaps
+your enemy might be made to donate some? You grab one of your needles and 
+violently scoop some out of them. This isn't exactly how it worked in med school.
+Make a melee attack against your enemy. If it hits, you get a contagion reward
+of 4, if it misses, you get nothing. You get a -20% to miss and deal damage 
+equal to 4 * Strength. Ignore armor. 
 
 /////	Poison: Thiopental Derivative
 Contagion Cost: 1


### PR DESCRIPTION
Uncouples Medics from nanites. 

Fixes Issues:
#60 
#61 
#62 
#64 

TL; DR Medics now use adrenaline points, needles and contagions instead of nanites. Nerfing almost all of the medic's malpractice powers by increasing their cost of entry. 

Work left to do: Remove nanite push and nanite wave. They are obviously out of character. Planning on using new DoT powers or something a little less control-oriented. 
