### PR TITLE
Update Basic Rules.txt for min-maxing, spelling fixes

### DIFF
--- a/play/PlayerRules/Basic Rules.txt
+++ b/play/PlayerRules/Basic Rules.txt
@@ -8,9 +8,9 @@ Premise:
 Welcome to Compound X! The specific time and place that your adventure takes
 place is up to your Game Master (often called a GM for short), but all of them
 take place far in the future where humans have left earth on their faster-than-light
-spaceships to explore dangerous new worlds frought with freind and foe of all
+spaceships to explore dangerous new worlds fraught with friend and foe of all
 manner of robots and aliens! 
-Will you be the dashing hero? Or perhaps the evil villian plotting galactic 
+Will you be the dashing hero? Or perhaps the evil villain plotting galactic 
 domination? Or maybe a mercenary who's somewhere in between? The choice is
 yours and your legend will be told as you play the game!
  
@@ -19,13 +19,13 @@ The Primary Game Mechanic:
 ==============================
 
 You may now be thinking to yourself; "Self-person, we sure can't wait to go
-galavanting through the galaxy doing fantastic things and seeing the beautiful
-galaxies! But how would we do that?" Well, youself doesn't have the answer yet,
+gallivanting through the galaxy doing fantastic things and seeing the beautiful
+galaxies! But how would we do that?" Well, yourself doesn't have the answer yet,
 but good news! You just found it!
 
 In Compound X, most things you will do will be accompanied by a 'roll'. That 
 translates to rolling the dice. Rolling the dice is our way of factoring in
-the human (or not human) tendancy to do things in a way which isn't perfect.
+the human (or not human) tendency to do things in a way which isn't perfect.
 When you roll high, you do very well. When you roll low, you goof up. But hold 
 your horses, or kangaroo or what have you. This is a strategy RPG, not a gambling game.
 Each roll will have numbers which you will add to or subtract from the one you 
@@ -59,13 +59,13 @@ still make up what you want to do, most actions fall into pre-existing categorie
 that take a specific amount of time and typically do a specified amount of damage. 
 More detail on that in the combat section of basic rules.
 
-Out of combat, turns are a little more fluid. Ususally players take their turn 
+Out of combat, turns are a little more fluid. Usually players take their turn 
 describing what they want to do when each player gets an idea of what to do.
-If two players have an idea at the same time, please be curteous and take turns. It's
+If two players have an idea at the same time, please be courteous and take turns. It's
 much easier for the GM to listen to one player at a time. In addition to taking 
 turns, please also be polite and share the spotlight. You ALL are the main heroes 
-or villians of this story. Make sure everyone gets a chance to do the one-liner they
-want, or to have their moment of badassitude.
+or villains of this story. Make sure everyone gets a chance to do the one-liner they
+want, or to have their moment of glory.
 
 Either in combat or out, play usually follows this loop:
 
@@ -79,7 +79,7 @@ Either in combat or out, play usually follows this loop:
 5.	The player rolls the dice and adds the numbers as described below.
 6. 	The GM checks their total against the Difficulty Challenge, a number that
 		typically only the GM knows which represents how hard a typical task
-		is. Then the GM narrarates how the action goes depending on if the 
+		is. Then the GM narrates how the action goes depending on if the 
 		player succeeds or fails and by how much.
 7.	Then the next player begins their turn.
 
@@ -93,7 +93,7 @@ jump right in and start playing, you need to create a character! This is often
 one of the most fun parts of the game!
 Making a character is a slightly involved process that can take a new player 
 up to two hours to fully flesh out. There are several parts of characters which
-are detailed below, but let's list them here breifly before we get into the 
+are detailed below, but let's list them here briefly before we get into the 
 nitty-gritty of it.
 
 Base Stats - These decide what raw characteristics make up your character, and 
@@ -106,7 +106,7 @@ Species/Race - Is your character a robot? What about a human? Or maybe the
 	different people in the galaxy accordingly.
 Class 		- Think of this like your job. Are you a sniper, waiting for the
 	perfect shot? Or are you a pilot who can thread a needle with your 
-	starfighter? Or maybe you're a verteran soldier, who's seen it all. 
+	starfighter? Or maybe you're a veteran soldier, who's seen it all. 
 	Classes define what armor and weapons your character can use in combat,
 	as well as certain special abilities which might help solve puzzles or
 	get you better discounts at stores. Your class also dictates how much 
@@ -116,9 +116,9 @@ Skills		- Each character learns things while going through life. Maybe
 	or maybe your time working at a mechanic's shop made you good at 
 	repairing things? Or maybe you're one of those people who is just
 	naturally good at hacking computers. Picking these numbers will
-	represent that in the game world.
+	represent that in the game world. 
 Equipment	- Your equipment is made up of your character's weapon, armor
-	and miscelanious items. You'll get money to buy them with at the start
+	and miscellaneous items. You'll get money to buy them with at the start
 	of the game and you'll earn more money as you go about your adventures.
 Feats		- Your character will gain special perks as you level up. This
 	could range from reloading really fast, to having more health to being
@@ -142,7 +142,7 @@ Dexterity
 and Luck.
 
 Usually you can tell a lot about a character just by their base stats. For
-instance, a character with 9 strength and 3 intelligence is usally either
+instance, a character with 9 strength and 3 intelligence is usually either
 a brutish bully or a tough but lovable teddy bear of a person. Where a 
 character with 10 intelligence and 2 charisma is probably a brilliant 
 nerd who might be shy or just have a terrible stutter.
@@ -167,51 +167,95 @@ and the score of your roll would be
 That's a really high roll! But that may or may not be enough to lift the object
 depending on how heavy it is!
 
-Each Base stat has a different specific effect. They are detailed below.
+Each Base Stat has different specific effects. They are detailed below.
 
-Strength: How strong are you? This stat dictates how big of a gun you can carry
-	and how hard you can punch or hit with strength melee weapons. It might
-	also allow you to solve puzzles with the brute force approach.
-Perception: Your ability to see, hear, smell and sense the world around you, as 
-	well as to interprit what those sensations indicate. Perception affects your
-	weapon accuracy and ability to cut through the chaos of battle to stay 
-	oriented. A high perception makes you harder to sneak up on. 
-Fortitude: How tough are you? Fortitude dictates your maximum health, how hard
-	you are to knock off of your feet and contributes to your saving throws.
-Charisma: How good are you at communicating with those around you? Charisma 
-	affects a number of interpersonal skills like haggling and diplomacy. It
-	also contributes to how hard it is to dominate your will.
-Intelligence: How smart are you? Intelligence dictates how many nanites you
-	have to cast spells with if you are a class that uses spells like an
-	engineer, warlock or medic. It also affects how quickly you pick up
-	new skills when you level up and makes you more proficient at using 
-	some of those skills.
-Dexterity: How nimble are you? Dexterity decides your maximum move speed in
-	combat, as well as how much damage you do with finess melee weapons like
-	knives. Dexterity also contributes to skill checks for doing things with
-	a character's body like climbing, jumping or dancing. 
-Luck: Some people are just lucky! A GM will often have you roll luck to see
-	if a door was left unlocked or if you just happened to duck to pick up 
-	a coin off the ground right when an assassin is trying to shoot you in
-	the head. Luck also has an effect on what loot you find in dungeons.
+Strength:
+	How strong are you? This stat dictates how big of a gun you can carry and
+	how hard you can punch or hit with strength melee weapons. It might also allow 
+	you to solve puzzles with the brute force approach.
+		If you have 1 Strength, you are exceptionally weak and your max movement per
+	2 actions is 2m (unless your Dex is 1) and you cannot wear armor that offers more 
+	than 50% coverage.
+Perception: 
+	Your ability to see, hear, smell and sense the world around you, as well as
+	to interpret what those sensations indicate. Perception affects your weapon 
+	accuracy and ability to cut through the chaos of battle to stay oriented. A high
+	perception makes you harder to sneak up on. 
+		If you have 1 Perception, you are partially blind, only have 1 eye, or
+	something similar. You cannot use the Search or Awareness skills and you have a 
+	-20 malus to Speech skill rolls. 
+Fortitude: 
+	How tough are you? Fortitude dictates your maximum health, how hard you are to 
+	knock off of your feet, and contributes to your saving throws.
+		If you have 1 Fortitude, you are exceptionally frail. You can't inflict lethal 
+	unarmed damage and your unarmed damage is halved. Also, when you deal melee damage, 
+	you inflict half of the damage on yourself.
+Charisma: 
+	How good are you at communicating with those around you? Charisma affects a 
+	number of interpersonal skills like haggling and diplomacy. It also contributes to 
+	how hard it is to dominate your will.
+		If you have 1 Charisma, you have a debilitating speech impediment. You have
+	an additional malus of -24 when using Speech, Deceive, and etc. skill. Under normal 
+	circumstances, you have to succed a DC 30 CHA skill check in order to communicate 
+	with a non-player character (NPC). In combat, vocal communication to anything costs
+	1 Action.
+Intelligence: 
+	How smart are you? Intelligence dictates how many Nanites you have to cast spells
+	with or use certain Feats and abilities. It also affects how quickly you acquire new
+	skills when you	level up and how proficient you are at using some of those skills.
+		If you have 1 intelligence, let's just say, you aren't particularly smart. 
+	You cannot attempt to use any skill that you do not have Proficiency in (see the 
+	"RP / Using Skills" section).
+Dexterity: 
+	How nimble are you? Dexterity decides your maximum move speed in combat, as well 
+	as how much damage you do with finesse melee weapons like knives. Dexterity also 
+	contributes to skill checks for doing things with a character's body like climbing,
+	jumping, or dancing.
+		If you have 1 Dexterity, you are especially clumsy or suffer from a debilitating
+	illness which affects your ability to move swiftly and precisely. You cannot learn any
+	skills that use Dexterity as the contributing stat (for example, lockpicking).
+Luck: 
+	Some people are just lucky! A GM will often have you roll luck to see if a door was
+	left unlocked or if you just happened to duck to pick up a coin off the ground right 
+	when an assassin is trying to shoot you in the head. Luck also has a significant effect
+	on what loot you find in dungeons and your chance to roll a critical hit.
+		If you have 1 Luck, it goes without saying, you are very unlucky. At the start of
+	a combat encounter, roll a d10 and receive a penalty from the Black Cat table, below.	
 
-
+					BLACK CAT TABLE	
+╔═══════╦═══════════════════════════════════════════════════════════════════════════════════════╗
+║ Roll  ║ Effect									  	║ 
+╠═══════╬═══════════════════════════════════════════════════════════════════════════════════════╣
+║ 1-2   ║ Your primary weapon malfunctions/breaks and you cannot use it until DC 60 repaired    ║
+╠═══════╬═══════════════════════════════════════════════════════════════════════════════════════╣
+║ 3-4   ║ You cannot crit or critically succeed (in any form) in this encounter			║
+╠═══════╬═══════════════════════════════════════════════════════════════════════════════════════╣
+║ 5-6   ║ You trip and hurt yourself, take 15 damage and lose three actions from your 1st turn  ║
+╠═══════╬═══════════════════════════════════════════════════════════════════════════════════════╣
+║ 7-8   ║ Mental breakdown, roll DC 75 Will save or gain status effect 'Fear' of enemies	║
+╠═══════╬═══════════════════════════════════════════════════════════════════════════════════════╣
+║ 9-10  ║ Nothing bad happens... this time							║
+╚═══════╩═══════════════════════════════════════════════════════════════════════════════════════╝
+	
+	
+	
 Leveling up:
 Gain feats according to the table below.
-With Charisma 9 or higher, recieve more feats. The feats listed are totals, not to be 
-added in addition.
-every level 2*int skill points,
+With Charisma 9 or higher, receive more feats. The feats listed in the table are totals, 
+not to be added together.
+every level, gain 2*int skill points
 every 5th level, +1 Class feat
 On levels 5, 9, 15 and 20, gain a stat point. The stat increase happens before any 
-calculations, so if you had 10 int, and increased to 11, you would get 22 skill 
-points for the level. Additionally, any stat point alteration forces a recalulation on all affected values.
+calculations, so if you had 10 int, and increased to 11, you would get 22 skill points
+for the level. Additionally, any stat point alteration forces a recalculation on all
+affected values.
 
 ╔═══════╦══════════╦═══════╦════════════╦════════════╦═══════════════╗
 ║ Level ║ Skill P. ║ Feats ║ Class Feat ║ Stat Point ║ Feats (9 CHA) ║
 ╠═══════╬══════════╬═══════╬════════════╬════════════╬═══════════════╣
-║ 0     ║  Given   ║   0   ║            ║            ║      0        ║
+║ 0     ║ Given    ║ 0     ║            ║            ║ 0             ║
 ╠═══════╬══════════╬═══════╬════════════╬════════════╬═══════════════╣
-║ 1     ║  Static  ║       ║            ║            ║               ║
+║ 1     ║ Static   ║       ║            ║            ║               ║
 ╠═══════╬══════════╬═══════╬════════════╬════════════╬═══════════════╣
 ║ 2     ║ 2*int    ║ 2     ║            ║            ║ 2             ║
 ╠═══════╬══════════╬═══════╬════════════╬════════════╬═══════════════╣
@@ -271,7 +315,7 @@ the equations are as follows:
     - Shock: 2*(Fort + Int - 6) Rational: You need to recognize that you are 
     	in shock, and resist its physical effects.
     - Reflex: 2*(Per + Dex - 6) Rational: In order to react quickly to an event
-    	, you also need to be able to see it coming.
+    	you need to be able to see it coming.
 
 ==============================
 Medicine Saving Throws
@@ -292,7 +336,7 @@ damage deficit (70-41), so the medic would need to roll over a DC of 29 to
 heal the remaining 29 damage. (Cannot overheal a wound).
 Medics need not use a medic-kit so long as the have their medicine bag (or 
 equivalent) on their person. If they do not have their medicine bag with them 
-when they are trying to heal a teamate, they can make the attempt at a +20 DC.
+when they are trying to heal a teammate, they can make the attempt at a +20 DC.
 Using a medikit:
 Medic-kit, non-medic user: works as if you are a medic with skill 30.
 Medic-kit, medic user: Works as normal, but add 30 to amount healed.
@@ -301,45 +345,49 @@ Medic-kit, medic user: Works as normal, but add 30 to amount healed.
 RP / Using Skills:
 ==============================
 The GM may ask you to roll a certain skill to see if your character can do 
-something. This may be something like "Roll Awareness to see if you spot the 
-truck barreling towards you," or it might look like "Roll Medicine to see if 
+something. This may be something like, "Roll Awareness to see if you spot the 
+truck barreling towards you," or it might look like, "Roll Medicine to see if 
 you can patch up the gaping wound in your chest spewing blood." Anytime you 
-need to Pass a Skill check, there will be a DC to overcome in order to 
-successfully pass the check. Again: YOU MUST ROLL *OVER* A DC TO PERFORM A 
-SKILL. the DC does not need to be given out by the GM, but if a DC seems too 
-high, you have the right to grumble (but seriously, ask your GM if something 
-seems too difficult. There is usually a reason why tying your shoe takes a DC 
-of 70% on that particular day, etc). After you have rolled, please apply any 
-and all relevant skills to your result. If you are rolling to silently take 
-down an opponent, the GM can either have you roll a stealth check and an 
+need to Pass a Skill check, there will be a DC (Difficulty Check) you have to 
+exceed in order to successfully pass the check. Again: YOU MUST ROLL *OVER* A DC 
+TO SUCCEED IN A SKILL CHECK. the DC does not need to be given out by the GM, but if
+a DC seems too high, you have the right to grumble (but seriously, ask your GM if 
+something seems too difficult. There is usually a reason why tying your shoe 
+takes a DC of 70% on that particular day, etc). After you have rolled, please
+apply any and all relevant skills to your result. If you are rolling to silently
+take down an opponent, the GM can either have you roll a stealth check and an 
 unarmed combat check, or double the DC, and have you roll once adding both 
-modfiers. Also add any relevant Stat Bonuses to a roll. When rolling 
+modifiers. Also add any relevant Stat Bonuses to a roll. When rolling 
 awareness, add your PER Bonus, etc.
 At any time out of combat, you may decide to use one of your skills. If you 
-are not preasured by imminant / immediate danger, you may take a 100% to pass 
+are not pressured by imminent / immediate danger, you may "take a 100%" to pass 
 a skill check, then apply any ranks in the skill. When rushed by a time 
-constraint or danger, you can take a 50% to pass a skill check, then apply any 
+constraint or danger, you can "take a 50%" to pass a skill check, then apply any 
 ranks in said skill. However, some checks cannot be passed in this way. If you 
-are staring at a ship''s blast doors, and want to kick them down, yeah . . . 
-good luck with that.
-If you want to use a skill in combat, see the Combat: Actions subsection.
+are staring at a ship''s blast doors, and want to kick them down, you can't take
+additional time to increase your odds of success.
+If you want to use a skill in combat, see the "Combat: Actions" subsection.
 Skill ranks are exact percentiles to pass a skill check. If you have 50 ranks 
 in a skill, then you have a +50% chance to pass a skill check for that skill. 
-Everytime you purchase a new skill for 10 Skill points, it starts as a +10 
-skill. When leveling up you may add up to 5 points to any one skill.
+Every time you purchase a new skill for 10 Skill points, it starts as a +10% 
+skill. When leveling up you may add up to 10 points to any one skill.
+Normally a character can attempt any skill check whether or not they have invested 
+in learning the skill; however, sometimes a character will have more penalties if
+they attempt to use a skill that they don't have "Proficiency" in. A character has 
+Proficiency in a skill when they have 10 or more skill points in that skill.
 
-Defenders win Ties for opossing rolls. If a character ties a DC they fail.
+Defenders win ties for opposing rolls. If a character ties a DC they fail.
 
 ==============================
 Player Weapon Customization:
 ==============================
 
-Weapon custimization can be done anytime you are in a town, space station, or 
+Weapon customization can be done anytime you are in a town, space station, or 
 other mercantile area. Ask the GM if there are weapon shops or kiosks around, 
 they should point you to one. From there you can apply upgrades and 
 attachments.
-THe GM may tell you specific attachments that are available, or they may say 
-you can just go about your usual custimization. Only one attachment can be 
+The GM may tell you specific attachments that are available, or they may say 
+you can just go about your usual customization. Only one attachment can be 
 used per section (unless specifically stated in the item''s description). 
 
 ==============================
@@ -353,18 +401,18 @@ attack. Each "Player turn" lasts 4-6 seconds, and consists of 4 "Actions"
 //Rules for stealth attack / flat foot
 //-20%, -10% crit, reduce chance to hit armour (20%?)
 //If your attack would normally force the target to roll a fort save, they are 
-//incapacitaed by default with no roll.
+//incapacitated by default with no roll.
 
 Melee Notes:
-A character occupies 1m of space. however, as Compund X is not played out on a 
+A character occupies 1m of space. however, as Compound X is not played out on a 
 squares-board, usually it doesn''t matter if two players are within the same 
 1m space.
 Two Players locked in melee combat are considered to be in adjacent 1m spaces, 
 not in the same 1m space. Have you ever seen a fight? you don't start 
-face-face unless you're at a bar.
+face-to-face unless you're at a bar.
 Generally speaking, once a character has initiated melee combat with another 
 character, they are both considered to be in "melee combat," and occupy 
-adjacent 1m spaces. At this point (unless one characteer has a cqb weapon) 
+adjacent 1m spaces. At this point (unless one character has a CQB weapon) 
 both characters are assumed to be using their fists or other melee weapons. If
 a character wishes to leave melee combat, they incur a "penalty attack." 
 Characters also incur "penalty attacks" when moving through or next to an 
@@ -373,12 +421,12 @@ has equipped, and when performing a skill check when in melee combat.
 Melee combat is relatively simple. To hit an enemy player, add your dexterity 
 or strength modifier to a roll, plus any relevant skill. The result must be 
 greater than the opponent''s DEX * 5 + any skill in combat (Guard DC). Your 
-damage dealt is based on your DEX or STR modifier. If you are weilding a 
+damage dealt is based on your DEX or STR modifier. If you are wielding a 
 weapon against an unarmed opponent, they may still incur damage depending on 
 their skill.
 A character may grapple another character when they are both in melee 
 distance. Doing so provides the grappled player a "penalty attack" on the 
-graPpling player. During grappling, both sides roll opposing grapple checks to 
+grappling player. During grappling, both sides roll opposing grapple checks to 
 see who maintains control. Once you have control you may make a grapple check 
 to subdue your opponent (either through choke-out, pin, or a joint lock). You 
 may also strike an opponent during grappling, but if the strike fails your 
@@ -401,7 +449,7 @@ turning on a flashlight - 1 Action
 Unholstering Pistol - 1 Action
 Performing a skill check (other than Awareness) - 1 Action
 Conversing with partners - Free Action
-Getting Bearings / non skill-based perception - Free Action
+Getting your bearings / non skill-based perception - Free Action
 
 Movement:
 You can run DEX number of meters per 2 actions. A character with 1 DEX can 
@@ -422,7 +470,7 @@ trigger, the gun fires and chambers a new round automatically one time. It
 takes 1 Action to fire a semi-auto weapon in this way. Some guns, 
 such as Shotguns and Bolt-Action sniper rifles require 2 Actions to fire 
 the gun, where the first Action is a trigger pull, and the second Action
-is the rechambering of the weapon.
+is the re-chambering of the weapon.
 To hit, Players must roll a percentile that is over their weapon's % miss 
 stat. When an enemy is in cover, their cover score is added to your weapon's 
 miss chance. If your normal miss chance is 25, and the enemy is in full cover, 
@@ -441,7 +489,7 @@ Gun Jams:
 On a roll of 00-01, the weapon Jams, necessitating a weapon skill check, DC 60.
 When a player is defending against a hit, they roll Percentiles under their 
 armor in order to apply a Damage Reduction, or to apply damage to their 
-Capacitive Sheilds if the player has them.
+Capacitive Shields if the player has them.
 
 Hip Firing doubles a weapon''s miss chance. It is much smarter to takes one 
 action to Aim, and spend the rest of your shots on firing. Its also a great 
@@ -449,7 +497,7 @@ idea to take an action at the end of your turn to "hunker," and gain a 25%
 cover advantage.
 
 Using Cover:
-Chances are, if an enemy can see you in Compund X, they can hit you. Using 
+Chances are, if an enemy can see you in Compound X, they can hit you. Using 
 cover will make it harder to be hit. You will encounter many types of cover 
 while adventuring throughout the galaxy. Many small objects provide only 
 partial cover, either by partially obscuring your silhouette, or by providing 
@@ -462,10 +510,10 @@ Hunkering: +25% on top of whatever cover you''re behind.
 
 Hunkering costs one action, and you cannot fire your weapons. Imagine 
 curling up in a ball, to pose the absolute smallest target possible. Its a 
-free action to de-hunker
+free action to un-hunker
 
 Reloading:
-When a gun runs out of amunition, the user must pause to reload. "But how long 
+When a gun runs out of ammunition, the user must pause to reload. "But how long 
 do I gotta be outta the battle?" Great question!
 Each gun has a "Reload DC," rated based on the skill and brevity of the 
 weapon''s reload. For example, an assault rifle, which has a very obvious 
@@ -479,13 +527,13 @@ time is halved (for Bolt-Actions it is reduced to 1 Action). On a failure,
 the reload time takes double.
 
 When players take more than 70 damage, they must roll a Shock save at a DC of 
-the damage taken. on fail they pass out. on success they stay conscious. When 
-players fail, they may roll each turn at a DC of 70 to wake up. They continune 
+the damage taken. On fail they pass out. on success they stay conscious. When 
+players fail, they may roll each turn at a DC of 70 to wake up. They continue 
 to roll either for (15 - FORT) turns, or until they pass.
 
 Conditions:
 Bleeding - d10/2+1 (drop the remainder) stackable damage per turn. Broken with 
-Medicine Skill check. DC varries. If you have a bleed condition, seek medical aid
+Medicine Skill check. DC varies. If you have a bleed condition, seek medical aid
 immediately, You CAN Bleed Out, you have been warned.
 Burning - 2d10 damage per turn. Broken with a Maneuver Skill Check. DC 40. 
 Every 2 turns, the degree of the burn intensifies
@@ -509,31 +557,31 @@ Plasma Burn - 1d10+1 stackable damage per turn, for 2 turns if the target's armo
 is pierced/missed. If the targets armor is hit/pierced, the armor's AP level is 
 reduced by 1, permanently (repairable, DC 60% Repair check), not stackable. 
 Poisoned - d10 damage per turn. After 5 turns, some poisons may induce 
-unconsciousness. DC 50, Fortitude. Greater / Lesser posion increases damage 
+unconsciousness. DC 50, Fortitude. Greater / Lesser poison increases damage 
 (+5/-5) and DC (+25,-10).
 
 ==============================
 Damage Types and Armour types
 ==============================
 
-There are 4 main types of damage in compound X: Balistic (conventional 
-firearms, bows), Laser, Plasma, and melee. Additionally, some Balistic, Laser 
-and melee weapons can deal non-lethal variants. These damage types interract 
-differently with the two types of armour. Balistic weapons and balistic armour 
+There are 4 main types of damage in compound X: Ballistic (conventional 
+firearms, bows), Laser, Plasma, and melee. Additionally, some Ballistic, Laser 
+and melee weapons can deal non-lethal variants. These damage types interact 
+differently with the two types of armour. Ballistic weapons and ballistic armour 
 are the first damage type and armour type players will come across. When 
-balistic armour is shot by a balistic weapon, the armour may apply some damage 
+ballistic armour is shot by a ballistic weapon, the armour may apply some damage 
 reduction, then the player takes damage. The second type of damage players may 
-come across is plasma. Plasma damage stacks, and interracts fairly neutrally 
-with both balistic and CS armours. Balistic armour applies some DR to any 
+come across is plasma. Plasma damage stacks, and interacts fairly neutrally 
+with both ballistic and CS armours. Ballistic armour applies some DR to any 
 plasma damage, but in turn the plasma will melt away part of the armour. One 
 Tenth of the plasma's damage is removed from the armour's hit percent. For CS 
 shields, Plasma deals full damage to the shielding, plus inflicts plasma burn 
-on the wearer. Laser damage is the third type f damage encountered by players. 
+on the wearer. Laser damage is the third type pf damage encountered by players. 
 All lasers deal burn damage on hit. Lasers are completely nullified by CS 
-shields, dealing all of their damage to the shielding, and inflicitng no burn 
+shields, dealing all of their damage to the shielding, and inflicting no burn 
 damage. Lasers deal full damage to armoured targets, and remove nothing off of 
-the armour's hit percent. If a player wearing balistic armour is hit with a 
-laser, they recieve damage as if they weren't wearing any armour.
+the armour's hit percent. If a player wearing ballistic armour is hit with a 
+laser, they receive damage as if they weren't wearing any armour.
 
 Beyond weapon damage there are also environmental threats to consider. An 
 important note is on fall damage. A player can fall up to their Dex/2 in 
@@ -556,14 +604,14 @@ There are a few classes which are able to cast spells, Paladins, Mages and
 Sorcerers. Casting spells is very similar to performing other actions. 
 Normally, a spell takes one action to cast. The performer of the spell will 
 have to pass a Skill DC in order to successfully cast the spell. This DC is 
-the number of nanites used to cast the spell, plus an bonuses the target gains 
+the number of Nanites used to cast the spell, plus an bonuses the target gains 
 from cover. For Mages and Sorcerers this is a Spellcast DC, and for Paladins 
 this is a Knowledge [Nanites] DC. Mages/Sorcerers can add any skill points 
 they have in Sorcery to their rolls, and Paladins may do the same with their 
 Knowledge [Nanites] skill. Some spells may also require the target to make a 
 saving throw in order to avoid the spell or negate its effects. Generally 
-speaking, spells have a range that is dependant on either the Charsima score 
-of the caster or the Charsima Modifier.
+speaking, spells have a range that is dependant on either the Charisma score 
+of the caster or the Charisma Modifier.
 
 ==============================
 Cloaking
@@ -571,7 +619,7 @@ Cloaking
 
 Cloaking is available in the armour section, but also available to some 
 classes as a class feature. For non-class cloakers, the rules are as follows:
-Expend 50 nanites to activate the cloaking shield. while moving, the cloak DC 
+Expend 50 Nanites to activate the cloaking shield. while moving, the cloak DC 
 is 30. while staying still, the cloak DC is 60. There is a tell-tale shimmer 
 in the cloak, as the micro-foil has a hard time keeping up with moving 
 environments. Once the wearer has settled down, the micro-foil is able to 


### PR DESCRIPTION
Addressing #114 

>When leveling up you may add up to __5__ points to any one skill.

1. _Emphasis mine_, I changed it to 10. I don't think we've been playing the game with that limit, up to this point.
But 5 points forces players to be very diverse considering an above average int player will have 14-20 skill points per level at the start of the game, which isn't ideal for social interaction. 
2. Added the min-maxing penalties to the Player Stats section.
3. Added the definition of Proficiency in the "RP / Using Skills" section
4. Made various spelling fixes and tried to improve the grammar in some sections