### PR TITLE
Stylize Tundari Document

### DIFF
--- a/CharacterCreation/01_03_Races_Tundari
+++ b/CharacterCreation/01_03_Races_Tundari
@@ -4,28 +4,31 @@ Tundari
 
 ===== Society =====
 
-The Tundari are a race of obligate carnivores from the planet Tundaar. Physically, 
+	The Tundari are a race of obligate carnivores from the planet Tundaar. Physically, 
 they span a wide size range, from the Chi’mau, who can range from 3’6” to 5’ and 
 85-130 lbs to the Sang’mau, at 6’ to 7’ and up to 400 lbs, and every size in-between. 
-Like humans, body types persist in many forms. 
-A sleek coat of fur covers these people, ranging widely in color and pattern. It 
+Like humans, body types persist in many forms.
+
+	A sleek coat of fur covers these people, ranging widely in color and pattern. It 
 tends to grow short and fine over the majority of the body, however, the face, head, 
 neck, and joints have been known to grow hair that is longer and coarser, having a 
 mane or scruff-like quality about it. 
-As many cultures mark themselves with tattoos, the Tundari also have their own method
+
+	As many cultures mark themselves with tattoos, the Tundari also have their own method
 of skin-marking. Some outliers will dye their fur, but that is generally frowned upon 
 by much of Tundari society. The traditional method of marking is called Aranga, 
 though many ranchers will would recognize the method as very similar to the freeze-
 branding they mark livestock with. Aranga, however, is far more intricate that simple 
 freeze-branding.
-As a carnivorous species, they have large, forward, wide-set eyes, clawed limbs and 
+
+	As a carnivorous species, they have large, forward, wide-set eyes, clawed limbs and 
 large, sharp teeth. Their ears sprout from closer to the top of their heads than the 
 sides, and can be triangular or round. 
 They are considered a hardy species, but have not adapted well to fight off poisons 
 or foreign contaminants. They are diurnal, and have low-light eyesight, but can 
 also see well in daylight. 
 
-Culturally and economically, the clans on the Tunadri homeworld have an instated 
+	Culturally and economically, the clans on the Tunadri homeworld have an instated 
 breeding season once every four years. Cubs born outside of this season are not 
 harmed, but their parents are firmly reprimanded for the first, and drastic measures 
 may be taken if a single family has multiple children outside of the typical breeding 
@@ -36,73 +39,83 @@ kept their population stable for the last three centuries, and no one seems incl
 to change their ways. Space exploration and colonization have begun to change that, 
 but many colonists still ascribe to the old mandates.
 
-Types:                            Biological
-                                  Mammalian
-                                  Warm-blooded 
-                                  Carnivorous 
+Types:
+* Biological
+* Mammalian
+* Warm-blooded 
+* Carnivorous 
 
-Weakness to Poisons/Contagions:   [Insert Poison rules here]
+	Weakness to Poisons/Contagions:   [Insert Poison rules here]
 
 
 ===== Language: Tuunra ===== 
 
-While different clans have their own unique dialects, they are similar enough that 
+	While different clans have their own unique dialects, they are similar enough that 
 they can be understood well by all. Tuunra features drawn-out vowels, soft consonants,
 and sounds such as clicks, chirps, trills, and a low rumbling that is nearly inaudible 
 to humans. There is another integral part of Tuunra that many species do not pick up
 on, and that is an intricate system of body language that involves both tail and ears.
 A Tundari that has lost their tail may have great difficulty getting their point across
 to others of their species.
-Tundari can communicate basic ideas and general instructions noiselessly. 
+
+	Tundari can communicate basic ideas and general instructions noiselessly. 
 
 ===== Names ===== 
 
-First names range very much as humans, as far as origin. Often having some significance 
+	First names range very much as humans, as far as origin. Often having some significance 
 with the family, first names are fairly arbitrary in much of Tundari society. Tribe and 
 clan names are held the most important, and as such, are always listed first.
 Some Tundari have been exiled, lost their clan names, or adopted their own. Others have 
 adopted names from the other cultures they now live in. 
 
-                      ===== Tuunra Name Examples =====
-                              Rra’Igri Chi’ro
-                              Sang’Aal Meari
-                              Chi’Mer Brea
-                              Chi’Krou Amri
-                              A’rhe Gaur
+== Tuunra Name Examples ==
+
+* Rra’Igri Chi’ro
+* Sang’Aal Meari
+* Chi’Mer Brea
+* Chi’Krou Amri
+* A’rhe Gaur
 
 ===== Available Traits =====
 
 Clawed:
-Already equipped with built-in weapons, the large claws on your forelimbs give you an 
+	Already equipped with built-in weapons, the large claws on your forelimbs give you an 
 advantage in hand-to-hand combat. 
 [Increased Damage for Hand-to-Hand]
 
 Soft-footed:
-An ambush predator, you are built for sneaking up on those around you. You know how to 
+	An ambush predator, you are built for sneaking up on those around you. You know how to 
 handle your weight and use the knowledge passed down by generations of hunters to keep 
-your presence a secret. 
+your presence a secret.
 [Stealth Rolls may be Averaged]
 
 Prehensile Tail: 
-You have spent a long time using your tail to do more than just talk with. You can grab
+	You have spent a long time using your tail to do more than just talk with. You can grab
 onto items, use it to aid in climbing, or even hang from it. 
 [Tail has ½ the carrying capacity of an arm when upright. Full when hanging/dangling]
+	
 	Note: Tails cannot bear the hanging weight of a Large individual.
 
-Toothed: As a predatory species, you have the customary long teeth that frighten many. 
+Toothed: 
+	As a predatory species, you have the customary long teeth that frighten many. 
 To you, they are commonplace, but to many others, they are far from ordinary. 
 [Gain Advantage on Intimidation Rolls toward and against Biological beings]
 
-===== Clans =====
+==============================
+Tundari Clans
+==============================
 
 ===== Rra’mau =====
 
 Size: Medium/Large
 Favored Terrain: Plains
 
-Appearance: These clans tend to have coats that range from tawny to sorrel. They are 
+Appearance: 
+	These clans tend to have coats that range from tawny to sorrel. They are 
 leaner than the Sang’mau, as a whole.
-Tribe: The most social of all the clans, Rra’mau is the face for intergalactic trade,
+
+Tribe: 
+	The most social of all the clans, Rra’mau is the face for intergalactic trade,
 policies, and general hospitality to outsiders. While the clans all meet together to 
 decide these policies beforehand, (usually) for the betterment of the species, Rra’mau
 merely figure-head the process to outsiders.
@@ -110,12 +123,12 @@ merely figure-head the process to outsiders.
 == Available Traits ==
 
 Hind-Claws:
-Digging into the ground with the large claws present on your hind-limbs spurs your 
+	Digging into the ground with the large claws present on your hind-limbs spurs your 
 ability to run much faster than your peers. [Round movement speed calculations up]
 
 
 Wide-faced:
-Many species seem to be drawn to your large eyes. You aren’t certain why, but it gives 
+	Many species seem to be drawn to your large eyes. You aren’t certain why, but it gives 
 you an advantage when attempting to persuade or charm members of other biological species. 
 [Persuade at Advantage once per individual]
 
@@ -126,11 +139,14 @@ you an advantage when attempting to persuade or charm members of other biologica
 Size: Large
 Favored Terrain: Forest/Jungle
 
-Appearance: Coat range from black to tawny to brighter colors such as orange and red. 
+Appearance: 
+	Coat range from black to tawny to brighter colors such as orange and red. 
 These tundari are larger, more powerful hunters than their cousins, relying more on brute 
 strength and ambushing than on speed. While the trees on Tundaar well supported the weight 
 of these people, it is hard to find natural equivalents on other planets.
-Tribe: Another very social clan, the Sang’mau were deemed too frightening to be the best 
+
+Tribe: 
+	Another very social clan, the Sang’mau were deemed too frightening to be the best 
 negotiators after first contact with the Terrans, when the visiting diplomat fainted at 
 the mere sight. More commonplace now, this clan tends to stay out of the direct Terran-
 Tundari diplomacy. 
@@ -138,34 +154,37 @@ Tundari diplomacy.
 == Available Traits ==
 
 Climbing: 
-A long tail and a lack of fear for heights allows climbing to come very naturally to you. 
+	A long tail and a lack of fear for heights allows climbing to come very naturally to you. 
 [Gain Advantage on STR-Athletics Checks when Climbing]
 
 Powerful: 
-Large, developed muscles allow you to carry more and hit harder. 
+	Large, developed muscles allow you to carry more and hit harder. 
 [Active Carry Penalties reduced. More Damage for Hand-to-Hand]
 
 
 
 ===== Chi’mau =====
+
 Size: Small
 Favored Terrain: Urban/Rocky
 
-Appearance: Coats range from a red-tawny to grey and black. These Tundari are the smallest 
+Appearance: 
+	Coats range from a red-tawny to grey and black. These Tundari are the smallest 
 in both size and number of the large clans. They are more solitary than either of the larger
 clans. 
 
-Swimmer: You are an expert at swimming. A thick coat of fur protects you from the chill of 
+Swimmer: 
+	You are an expert at swimming. A thick coat of fur protects you from the chill of 
 the water, and you can hold your breath for quite some time.
 
 == Available Traits ==
  
 
 Climbing: 
-A long tail and a lack of fear for heights allows climbing to come very naturally to you. 
+	A long tail and a lack of fear for heights allows climbing to come very naturally to you. 
 [Gain Advantage on DEX-Acrobatics Checks when Climbing]
 
 Survivalist: 
-Being out by yourself often requires quick ingenuity and hardiness. 
-[Gain Proficiency in Jerry-Rigging]
+	Being out by yourself often requires quick ingenuity and hardiness. 
+[Gain Proficiency in Jury-Rigging]
 


### PR DESCRIPTION
Bringing Tundari document into style compliance.

Of note, I have changed the Clans section header into a Tundari Clans chapter header, in order to make the header hierarchy of that section behave. If we prefer not to separate these into different chapters, we can instead leave Clans as a section and have both the clan and its traits be separate subsections a la 

	 ===== Clans =====
	 
	 == Rra’mau ==
	 
	 == Rra'mau Traits ==