### PR TITLE
Mh issue 316 disrupted

### DIFF
--- a/01_02_Conditions.txt
+++ b/01_02_Conditions.txt
@@ -18,12 +18,6 @@ Every 2 turns, the degree of the burn intensifies
     Your health has fallen below 0. See the "Death and Dying" section in the 
 Basic Rules Document.
 
-== Disrupted ==
-
-    You cannot use Nanite abilities, Doctor Procedures, Engineer Processes or 
-Hacker Exploits. Many similar abilities are also prone to Disruption. If they
-are not on this list, consult your GM. 
-
 == Frozen ==
 
     d10 damage per turn. lasts until a source of heat is applied to the wound, 

--- a/01_02_Conditions.txt
+++ b/01_02_Conditions.txt
@@ -18,6 +18,12 @@ Every 2 turns, the degree of the burn intensifies
     Your health has fallen below 0. See the "Death and Dying" section in the 
 Basic Rules Document.
 
+== Disrupted ==
+
+    You cannot use Nanite abilities, Doctor Procedures, Engineer Processes or 
+Hacker Exploits. Many similar abilities are also prone to Disruption. If they
+are not on this list, consult your GM. 
+
 == Frozen ==
 
     d10 damage per turn. lasts until a source of heat is applied to the wound, 

--- a/CharacterCreation/Class-Specific Documentation/Doctor Procedures.txt
+++ b/CharacterCreation/Class-Specific Documentation/Doctor Procedures.txt
@@ -325,12 +325,11 @@ Contagion Cost: 1 Contagion
 Duration: 	almost instantaneous
 Range:		Payload (use in combination with other powers)
     A biologic target afflicted with this poison must succeed on a DC 110 FORT 
-save or the target takes 180 damage that ignores shields and armor and silences 
-the target. If the target succeeds on their save, they take 60 damage instead. A 
-silenced target is prevented from using abilities that use Nanites for 10 turns. 
-(Also prevents Engineering Processes and Doctor Procedures due to violent 
-tremors). At level 13, damage increases to 220. Does not prevent unarmed or 
-attacks with guns or melee weapons.
+save or the target takes 180 damage that ignores shields and armor and Disrupts 
+the target for up to 10 turns or a WILL save of DC 92 whichever is first. If the 
+target succeeds on their save, they take 60 damage instead. See 
+"01_02_conditions.txt" for the Disrupted Condition. At level 13, damage 
+increases to 220. Does not prevent unarmed or attacks with guns or melee weapons.
 
 ==Plague ==
 Adrenaline Cost: 250 Points

--- a/CharacterCreation/Class-Specific Documentation/Doctor Procedures.txt
+++ b/CharacterCreation/Class-Specific Documentation/Doctor Procedures.txt
@@ -325,11 +325,12 @@ Contagion Cost: 1 Contagion
 Duration: 	almost instantaneous
 Range:		Payload (use in combination with other powers)
     A biologic target afflicted with this poison must succeed on a DC 110 FORT 
-save or the target takes 180 damage that ignores shields and armor and Disrupts 
-the target for up to 10 turns or a WILL save of DC 92 whichever is first. If the 
-target succeeds on their save, they take 60 damage instead. See 
-"01_02_conditions.txt" for the Disrupted Condition. At level 13, damage 
-increases to 220. Does not prevent unarmed or attacks with guns or melee weapons.
+save or the target takes 180 damage that ignores shields and armor and silences 
+the target. If the target succeeds on their save, they take 60 damage instead. A 
+silenced target is prevented from using abilities that use Nanites for 10 turns. 
+(Also prevents Engineering Processes and Doctor Procedures due to violent 
+tremors). At level 13, damage increases to 220. Does not prevent unarmed or 
+attacks with guns or melee weapons.
 
 ==Plague ==
 Adrenaline Cost: 250 Points


### PR DESCRIPTION
There was an accidental merge to dev, which was reverted. Which is why this took 3 commits instead of 1 clever one. 

@Reveraine says that "disrupted" implies an instant reaction to her, rather than an ongoing condition. If that resonates with other's interpritations, we'll have to find another word. 