### PR TITLE
added 2 slot requirement for large munitions

### DIFF
--- a/CharacterCreation/04_06_MachineGuns_HeavyWeps_&_RocketLaunchers.txt
+++ b/CharacterCreation/04_06_MachineGuns_HeavyWeps_&_RocketLaunchers.txt
@@ -9,7 +9,9 @@ without 2x+ magnification.
 MACHINE GUNS
 ==============================
     For sustained automatic fire, machine-guns are the first choice.
-Minimum Strength 6. Reload time is 3 Actions. Jam range 2%.
+Minimum Strength 6. Reload time is 3 Actions. Jam range 2%. Some Machine Guns
+have large magazines that take up more than one mag slot in your armor. Please
+see specific weapons for notes on magazine size. 
 
 	All Machine-Guns have "Suppression Level - Heavy" (unless otherwise noted).
 
@@ -32,6 +34,8 @@ Movement Speed Penalty: -2m
 * 3 out to 15m
 * 4 out to 45m
 * 5 out to 90m
+
+    The ECSC Mk15R2 has large magazines that take up 2 magazine slots.
  
 ==Anvil Arms KMR4 $2854 ==
 
@@ -50,6 +54,8 @@ Movement Speed Penalty: -2.5m
 * 3 out to 15m
 * 4 out to 40m
 * 5 out to 85m
+
+    The Anvil Arms KMR4 has large magazines that take up 2 magazine slots.
 
 ===== Level 5 Weapons =====
 
@@ -70,6 +76,8 @@ Movement Speed Penalty: -2m
 * 3 out to 15m
 * 4 out to 50m
 * 5 out to 90m
+
+    The ECSC Mk249 has large magazines that take up 2 magazine slots.
  
 == Frontier LMG-P8 $3543 ==
 
@@ -88,7 +96,7 @@ Movement Speed Penalty: -2m
 * 2 out to 15m
 * 4 out to 45m
 * 5 out to 80m
- 
+
 ==Matthews Model 240-B  $4450 ==
 
 Damage: 105 Ballistic
@@ -106,6 +114,8 @@ Movement Speed Penalty: -2.5m
 * 2 out to 15m
 * 3 out to 50m
 * 4 out to 90m
+
+    The Mathews Model 240-B has large magazines that take up 2 magazine slots.
 
 ===== Level 10 Weapons =====
 
@@ -126,6 +136,8 @@ Movement Speed Penalty: -2.5m
 * 2 out to 15m
 * 3 out to 70m
 * 3 out to 95m
+
+    The Partix Laser LMA210 has large magazines that take up 2 magazine slots.
  
 ==Frontier LMG-P10 $6132 ==
 
@@ -144,6 +156,8 @@ Movement Speed Penalty: -3m
 * 2 out to 15m
 * 3 out to 55m
 * 5 out to 90m
+
+    The Frontier LMG-P10 has large magazines that take up 2 magazine slots.
 
 ==============================      
 HEAVY WEAPONS
@@ -182,6 +196,9 @@ attachments.
 * 2 out to 10m
 * 4 out to 15m
 * 5 out to 20m
+
+    The Frontier Flame Thrower FLMR has large magazines that take up 2 magazine 
+slots.
  
 ==Anvil Arms XM-50 Microgun $2135 ==
 
@@ -205,6 +222,9 @@ strength to lug around, 5 to use.
 * 5 out to 30m
 * 6 out to 70m
 
+    The Anvil Arms XM-50 Microgun has large magazines that take up 2 magazine 
+slots.
+
 ===== Level 5 Weapons =====
 
 ==Matthews TX-6 Rotary Grenade Launcher $2705 ==
@@ -225,12 +245,13 @@ All 40mm grenades explode on impact (DC 100% PER or LUCK check to dodge or take
 reduced damage) and have a -1m max explosion radius, unless otherwise stated. 2 
 Action reload.
 
-
 	Ranged Miss Chance 
 
 * 3 out to 10m
 * 4 out to 30m
 * 5 out to 60m
+
+    Rotary Grenade Drums are very large magazines that take up 2 mag slots each.
  
 ==Partix LX Lightning Gun $2693 ==
 
@@ -293,7 +314,8 @@ Movement Speed Penalty: -3m
 	Requires 1 Action of spin-up time. Fires 20 bullets (roll once for two 
 bullets for miss chance, but once per bullet on armor rolls) per Action, round 
 down. Jam range 2%. No optics, barrel attachments or extended mags. Requires 5 
-strength to lug around, 6 to use.
+strength to lug around, 6 to use. Minigun magazines are very large and take up
+two magazine slots each.
 
     Ranged Miss Chance
 
@@ -324,7 +346,8 @@ Movement Speed Penalty: -3m
 20m, 37x3 out to 50m. Hits every hit-able part of the body (e.g.: 60 damage to 
 chest, legs, and arms @ 5m) (automatically hits armor if present). Hits all 
 targets 1m adjacent to the primary target after 10m. 2m adjacent to the primary 
-target after 20m. No optics or barrel attachments.
+target after 20m. No optics or barrel attachments. Flack Cannon shells are very
+large and their magazines each take up 2 magazine slots.
  
 ==Strudwick Arms Ultralight Autocannon UA-6C $3896 ==
 
@@ -347,6 +370,8 @@ Movement Speed Penalty: -3m
 primary target, 70 Explosive Damage to other targets in a 2m radius. Damages 
 vehicles. Each shot into a door reduces the DC of kicking down that door by 65. 
 If the DC becomes 0, the door is blown open. No optics or barrel attachments.
+Autocannon shells are very large compared to bullets and their magazines each
+take up 2 magazine slots in your armor.  
  
 ==Shiva Antimaterial Rifle SAR $7144 ==
 

--- a/CharacterCreation/04_06_MachineGuns_HeavyWeps_&_RocketLaunchers.txt
+++ b/CharacterCreation/04_06_MachineGuns_HeavyWeps_&_RocketLaunchers.txt
@@ -161,17 +161,16 @@ Movement Speed Penalty: -3m
 
 ==============================      
 HEAVY WEAPONS
-==============================   
-    "Michael, what are these things again? One of these has multi-spinning 
-barrels and another spits lightning like a wozerd."
-
+============================== 
 	Do you want to consume your foes in hails of expensive bullets? Well, you're 
 in the right place. (use-with-caution.-some-weapons-have-been-known-to-cause-
 cancer-in-the-state-of-_REDACTED_.-If-you-experience-urges-to-light-people-on-
 fire-or-scream-maniacally-this-may-be-a-sign-of-a-serious-condition-please-
 consult-with-your-local-space-physician)      
 
-	Minimum Strength 6. Reload time is 3 Actions.     
+	Minimum Strength 6. Reload time is 3 Actions. Some Heavy Weapons have large 
+magazines that take up more than one mag slot in your armor. Please see specific 
+weapons for notes on magazine size. 
       
 ===== Level 1 Weapons =====
 


### PR DESCRIPTION
Should fix Issue #373. Intentionally left antimaterial single rod shots as a single mag, as well as a few of the laser guns, which I think would have smaller batteries. 