### PR TITLE
Mh issue 352 cerbe turret

### DIFF
--- a/03_Glossary_of_Terms.txt
+++ b/03_Glossary_of_Terms.txt
@@ -83,6 +83,12 @@ Held Actions:
 to a trigger outside of your turn. See "Reactions & Held Actions" in the basic 
 rules document.
 
+IO Ports:
+    Short for Input/Output Ports. Engineer Class Characters can build Drones and
+some Buildings which have a number of IO Ports which can have Peripherals added
+to them. See "Character Creation/Class Specific Documents/Engineering 
+Processes.txt" specifically the "IO Ports" subsection for more information.
+
 Nanite Upkeep:
     Nanite Upkeep is the number of nanites a character must pay at the end of 
 their turn in order to stay cloaked during that round. For more information,

--- a/CharacterCreation/Class-Specific Documentation/Engineer Processes.txt
+++ b/CharacterCreation/Class-Specific Documentation/Engineer Processes.txt
@@ -520,6 +520,9 @@ saying this is that if a Drone has 3 IO Ports, you can't build 4 Peripherals
 onto it and have the Drone turn peripherals off or on as it wants to; every
 Peripheral must have an active IO Port or it simply falls off of the Drone. 
 
+    IO Ports are a real-world Computer/Electric Engineering term which is short
+for Input/Output Ports.
+
 ===== Embedded Systems =====
 
 == Dragonfly	== 

--- a/CharacterCreation/Class-Specific Documentation/Engineer Processes.txt
+++ b/CharacterCreation/Class-Specific Documentation/Engineer Processes.txt
@@ -667,7 +667,8 @@ takes 3 burn tokens and 50 fire damage. They move slowly and have trouble with
 stairs, but their turret can quickly turn and fire. See the table below for 
 stats on the armor of the drone when built by Engineers of different levels. 
 One anti-vehicle hit will down them however. The Cerberus is large enough for a 
-player to take partial cover behind. 
+player to take partial cover behind. See the table below for stats on the main
+turret.
 
     When a drone is reclaimed, it frees up the control point cost that it 
 occupied, but does not reimburse its construction cost.
@@ -683,6 +684,20 @@ occupied, but does not reimburse its construction cost.
 +----------------+----------------+-----+-----+
 |       >19      |       100%     | 10  | 200 |
 +----------------+----------------+-----+-----+
+
+Cerberus Turret specs:
+
+Damage: 90 Explosive Damage
+APL: 4
+Capacity: 1 Round
+Reload Time: 1 Action
+Reflex Modifier: -35
+
++---------+-------+------+-----+
+| Range   |   5m  |  20m | 60m |
++---------+-------+------+-----+
+| To miss |   2   |   4  |  6  |
++---------+-------+------+-----+
 
 
 == Titan Multipurpose Drone	==


### PR DESCRIPTION
For context, the Cerberus attack Drone is available earliest at level 7, please note the drone's very low hack DCs as a balance point. This should address Issue #352. 