### PR TITLE
Skills consistency pass

### DIFF
--- a/01_01_Basic_Rules.txt
+++ b/01_01_Basic_Rules.txt
@@ -515,11 +515,11 @@ forces a recalculation on all affected values.
 +-------+----------+-------+------------+------------+---------------+
 | 1     | Static   |       |            |            |               |
 +-------+----------+-------+------------+------------+---------------+
-| 2     | 2*int/cha| 2     |            |            | 2             |
+| 2     | 2*Skill  | 2     |            |            | 2             |
 +-------+----------+-------+------------+------------+---------------+
-| 3     | "        |       |            |            |               |
+| 3     | Point    |       |            |            |               |
 +-------+----------+-------+------------+------------+---------------+
-| 4     | "        | 3     |            |            | 4             |
+| 4     | Gain     | 3     |            |            | 4             |
 +-------+----------+-------+------------+------------+---------------+
 | 5     | "        |       | 1          | +1         |               |
 +-------+----------+-------+------------+------------+---------------+
@@ -677,13 +677,14 @@ TO SUCCEED IN A SKILL CHECK. the DC does not need to be given out by the GM, but
 a DC seems too high, you have the right to grumble (but seriously, ask your GM if 
 something seems too difficult. There is usually a reason why tying your shoe 
 takes a DC of 70% on that particular day, etc). After you have rolled, please
-apply any and all relevant skills to your result. Also add any relevant Stat Bonuses to a roll. When rolling 
-awareness, add your PER Bonus, etc.
+apply any and all relevant skills to your result. Also add any relevant Stat Bonuses
+to a roll. When rolling investigation, add your PER Bonus, etc.
 
 	At any time out of combat, you may decide to use one of your skills. If you 
 are not pressured by imminent / immediate danger, you may "take a 100%" to take your
 time with a task to roll exactly 100 on a skill check, then apply any ranks in the
-skill. When rushed by a time constraint or danger, you can "take a 50%" to take
+skill. 
+	When rushed by a time constraint or danger, you can "take a 50%" to take
 slightly more time than a 1-action, in-combat check on a task to roll exactly 50 on
 a skill check, then apply any ranks in said skill. However, some checks cannot be
 passed in this way. If you are staring at a ship's blast doors, and want to kick

--- a/01_01_Basic_Rules.txt
+++ b/01_01_Basic_Rules.txt
@@ -1028,8 +1028,7 @@ of 7-10 would be successful.
 Gun Jams:
 	If at any time that you are firing a gun and you roll a weapon accuracy of 1,
 roll a second d10. If that second d10 roll is a 1 or 2, the weapon Jams, 
-necessitating a Weapon [X] skill check, DC 60. Your GM may allow you to add skill in
-Repair to this check.
+necessitating a Weapon [X] skill check, DC 60.
 
 Hip Firing:
 	Add 3 to a weapon's miss chance. You cannot use optical attachments in hip 

--- a/01_01_Basic_Rules.txt
+++ b/01_01_Basic_Rules.txt
@@ -325,7 +325,7 @@ accuracy and ability to cut through the chaos of battle to stay oriented. A high
 perception makes you harder to sneak up on. 
 
 	If you have 1 Perception, you are partially blind, only have 1 eye, or
-something similar. You cannot use the Search or Awareness skills and you have a 
+something similar. You cannot use the Investigation or Spotting skills and you have a 
 -20 malus to Speech skill rolls. 
 
 Fortitude (FORT): 
@@ -384,7 +384,7 @@ body like climbing, jumping, or dancing.
 	If you have 1 Dexterity, you are especially clumsy or suffer from a 
 debilitating illness which affects your ability to move swiftly and precisely. 
 You cannot learn any skills that use Dexterity as the contributing stat (for 
-example, lockpicking).
+example, Slight of Hand).
 
 Luck (LUCK): 
 	Some people are just lucky! A GM will often have you roll luck to see if a 
@@ -515,7 +515,7 @@ forces a recalculation on all affected values.
 +-------+----------+-------+------------+------------+---------------+
 | 1     | Static   |       |            |            |               |
 +-------+----------+-------+------------+------------+---------------+
-| 2     | 2*int    | 2     |            |            | 2             |
+| 2     | 2*int/cha| 2     |            |            | 2             |
 +-------+----------+-------+------------+------------+---------------+
 | 3     | "        |       |            |            |               |
 +-------+----------+-------+------------+------------+---------------+
@@ -668,8 +668,8 @@ RP / Using Skills
 ==============================
 
 	The GM may ask you to roll a certain skill to see if your character can do 
-something. This may be something like, "Roll Awareness to see if you spot the 
-truck barreling towards you," or it might look like, "Roll Medicine to see if 
+something. This may be something like, "Roll Sleight of Hand to see if you can
+pick the lock on that door," or it might look like, "Roll Medicine to see if 
 you can patch up the gaping wound in your chest spewing blood." Anytime you 
 need to Pass a Skill check, there will be a DC (Difficulty Check) you have to 
 exceed in order to successfully pass the check. Again: YOU MUST ROLL *OVER* A DC 
@@ -677,33 +677,34 @@ TO SUCCEED IN A SKILL CHECK. the DC does not need to be given out by the GM, but
 a DC seems too high, you have the right to grumble (but seriously, ask your GM if 
 something seems too difficult. There is usually a reason why tying your shoe 
 takes a DC of 70% on that particular day, etc). After you have rolled, please
-apply any and all relevant skills to your result. If you are rolling to silently
-take down an opponent, the GM can either have you roll a stealth check and an 
-unarmed combat check, or double the DC, and have you roll once adding both 
-modifiers. Also add any relevant Stat Bonuses to a roll. When rolling 
+apply any and all relevant skills to your result. Also add any relevant Stat Bonuses to a roll. When rolling 
 awareness, add your PER Bonus, etc.
 
 	At any time out of combat, you may decide to use one of your skills. If you 
-are not pressured by imminent / immediate danger, you may "take a 100%" to pass 
-a skill check, then apply any ranks in the skill. When rushed by a time 
-constraint or danger, you can "take a 50%" to pass a skill check, then apply any 
-ranks in said skill. However, some checks cannot be passed in this way. If you 
-are staring at a ship''s blast doors, and want to kick them down, you can't take
-additional time to increase your odds of success.
+are not pressured by imminent / immediate danger, you may "take a 100%" to take your
+time with a task to roll exactly 100 on a skill check, then apply any ranks in the
+skill. When rushed by a time constraint or danger, you can "take a 50%" to take
+slightly more time than a 1-action, in-combat check on a task to roll exactly 50 on
+a skill check, then apply any ranks in said skill. However, some checks cannot be
+passed in this way. If you are staring at a ship's blast doors, and want to kick
+them down, you can't take additional time to increase your odds of success.
 
 	If you want to use a skill in combat, see the "Combat: Actions" subsection.
 Skill ranks are exact percentiles to pass a skill check. If you have 50 ranks 
 in a skill, then you have a +50% chance to pass a skill check for that skill. 
-Every time you purchase a new skill for 10 Skill points, it starts as a +10% 
-skill. When leveling up you may add up to 10 points to any one skill.
+When leveling up you may add up to 5 points to any skill.
 
-	Normally a character can attempt any skill check whether or not they have 
-invested in learning the skill; however, sometimes a character will have more 
-penalties if they attempt to use a skill that they don't have "Proficiency" in. 
-A character has Proficiency in a skill when they have 10 or more skill points in 
-that skill.
+	In many cases, a character can attempt a skill check whether or not they
+have invested in learning the skill; however, your GM may decide otherwise, apply
+penalties to your roll, raise the DC, ask you to justify why your character can
+attempt the roll, or make any other judgement they deem appropriate. 
 
-	Defenders win ties for opposing rolls. If a character ties a DC they fail.
+	Characters are considered to be Proficient with certain skills, based on
+their class and background. When a character is Proficient in a skill, each skill 
+point they spend in that skill upon leveling up increases that skill by two 
+instead of one.
+
+	Defenders win ties for opposing rolls.
 
 ==============================
 Player Weapon Customization
@@ -765,16 +766,14 @@ standard Hip Firing rules apply.
 Making Melee Attacks:
 	Melee combat is relatively simple. To hit an enemy player: add your 
 dexterity combat modifier to a d10 roll plus your combat modifier from your 
-weapon/attack*, and add any relevant skill(s)**. The result must be greater than 
-the opponent's Guard DC: 
+weapon/attack*. The result must be greater than the opponent's Guard DC: 
 
-	(DEX * 4)/10 + any skill** in combat. 
+	(DEX * 4)/10  
 
 	Drop any decimal remainder. If you successfully hit your opponent, you roll 
 armor as normal (for more details, see below sections "Armor and Getting Hit" 
 and "Damage Types and Armor Types"). Your damage dealt is often based on a 
-combination of your DEX and STR. If you are wielding a weapon against an unarmed 
-opponent, they may still incur damage depending on their skill.
+combination of your DEX and STR.
 
 	NOTE: if you are fighting unarmed, you can (normally) deal full non-lethal 
 damage or half lethal damage (your choice). Non-lethal damage should be recorded 
@@ -783,10 +782,6 @@ the target becomes unconscious/incapacitated.
 
 *Modifiers from specific weapons or unarmed[x] attacks are listed in the weapons 
 document.
-
-**To determine bonus modifiers from skill, for every 5 skill points in a relevant 
-skill (such as "melee combat skill") take a bonus +0.5 when rolling against guard 
-DC. Drop any decimal remainder after adding all the modifiers.
 
 Hitting What You Intend:
 	If you roll 3+ above your miss chance (3+ above the opponent's guard DC), 
@@ -826,7 +821,7 @@ Cast a Spell: 1 Action
 Aiming Down Gun Sights: 1 Action
 Turning on a Flashlight: 1 Action
 Unholstering Pistol or Grabbing a Weapon/Item: 1 Action
-Performing a Skill Check (other than Getting Bearings/Awareness of surroundings): 1 Action
+Performing a Skill Check (other than Getting Bearings): 1 Action
 Conversing With Partners: Free Action
 Getting Your Bearings / Non Skill-Based Perception: Free Action
 
@@ -867,7 +862,7 @@ can move 1m per 2 actions, or 2m per 4 actions (a full turn). You can sprint
 instead of running, for a +1 movement bonus per action. However, firing your 
 weapon after doing so will cause you to incur a +1 miss chance penalty. The 
 penalty occurs during the actions you sprint, as well as 2 actions afterwards. 
-You can sprint for a number of subsequent Actions equal to your Fortitude. You 
+You can sprint for a number of consecutive Actions equal to your Fortitude. You 
 can jump horizontally Dex/2 meters, and add 1m if you have a 3m running start.
 You can jump vertically Str/3 meters.
 
@@ -951,16 +946,11 @@ other thrown weapons) have -1 miss chance to hit if 'adequate' aiming time is
 given (DM's discretion: how rushed you are, or how skilled you are at stealth, 
 etc). Ranged weapon stealth-attacks gain +20 bonus damage.
 
-	If you stealth-attack a target in melee, your target has a guard DC of 0. If 
-you have at least 10 skill in melee combat and you attack from stealth, Thrown 
-and Melee (non-explosive/non-grenade) weapons deal 2x BASE Damage*, up to 150 
-maximum damage** (critical/BONUS damage is not doubled, but added on to the 2x 
-Base Damage). If you critically hit, you ignore the opponent's armor and deal 
-full damage. Or, as normal, (see section, "melee combat") if you roll 3+ above 
-your miss chance (3+ above the opponent's guard DC), you ignore the opponent's 
-armor and deal full damage. Signifying that the target gets hit in whatever you 
-deem to be the most vulnerable; i.e., the head, neck, or the chest (over the 
-heart, etc). 
+	If you stealth-attack a target in melee, your target has a guard DC of 0. As
+normal (see section, "melee combat"), if you roll 3+ above your miss chance (3+ above
+the opponent's guard DC), you ignore the opponent's armor and deal full damage.
+This signifies that the target gets hit in whatever you deem to be the most vulnerable;
+i.e., the head, neck, or the chest (over the heart, etc). 
 
 *Base Damage is typically the damage of the weapon without any other character 
 bonuses, but Base Damage can be increased by certain classes and abilities.
@@ -977,7 +967,7 @@ from flanking.)
 	If a player or opponent is standing outside of cover and they are shot at, 
 after the first firing action (assuming they didn't die or go unconscious), 
 they immediately, 'Hit the Dirt'. When you Hit the Dirt, you dive to the ground,
-going prone, within a 2m range of where they stood (DEX movement rules apply 
+going prone, within a 2m range of where you stood (DEX movement rules apply 
 as normal). Hitting the dirt consumes the 1st action of their next turn.
 
 	To fire, you must be within the longest range limit of your gun*, i.e. be at 
@@ -1011,7 +1001,7 @@ in any of the following circumstances:
 unexpected, then the character may shift aim to another target within 5m of the first 
 as a Free Action. DM discretion is advised for close combat situations.
 
-***Possibly by coming out of cover 5+ meters from the last known location.
+****Possibly by coming out of cover 5+ meters from the last known location.
 
 	Aiming is relatively simple and does not need to be treated with excessive
 formality. If a character could reasonably take or keep aim at something, then he or 
@@ -1038,7 +1028,8 @@ of 7-10 would be successful.
 Gun Jams:
 	If at any time that you are firing a gun and you roll a weapon accuracy of 1,
 roll a second d10. If that second d10 roll is a 1 or 2, the weapon Jams, 
-necessitating a weapon skill check, DC 60. 
+necessitating a Weapon [X] skill check, DC 60. Your GM may allow you to add skill in
+Repair to this check.
 
 Hip Firing:
 	Add 3 to a weapon's miss chance. You cannot use optical attachments in hip 
@@ -1086,9 +1077,9 @@ sprint or use other movement abilities.
 
 	Going prone costs 1 Action, and standing up costs 1 Action. Lying flat down on
 your chest makes you a smaller target and helps you aim better, but also makes you
-easier to hit in melee. -1 gun miss chance while prone and +2 chance to be hit in
-melee. Being prone severely limits your movement: 1/2 movement speed while prone, 
-round-up; maximum 2 movement per action.
+easier to hit in melee. -1 gun miss chance while prone and -2 melee Guard DC. Being
+prone severely limits your movement: 1/2 movement speed while prone, round-up; maximum
+2 movement per action.
 
 	Hunkering costs 1 action, and you cannot fire your weapons except by blind-fire 
 (see Blind Firing, above). Imagine curling up in a ball, to pose the absolute smallest
@@ -1105,8 +1096,8 @@ complex weapons, such as high-precision sniper systems or exotic sub-machine
 guns might have a higher DC, maybe 40%. If the Player passes the reload, then 
 the reload time is standard. For Box-Magazine fed Semi- and Fully-Automatic 
 weapons, this is 2 Actions. Other, more complex weapons will specify their 
-reload time. On a critical reload success (effected by luck as normal, anything 
-in the 90-100 range caused by a raw roll or by adding your weapon use skill),
+reload time. On a critical reload success (affected by luck as normal, anything 
+in the 90-100 range caused by a raw roll or by adding your Weapon [X] skill),
 the reload time is halved (for Bolt-Actions it is reduced to 1 Action). On a 
 failure, the reload time takes twice as long.
 

--- a/01_01_Basic_Rules.txt
+++ b/01_01_Basic_Rules.txt
@@ -432,8 +432,7 @@ penalties.
 Skill Point Gain:
 	How many skill points you gain every level. Every time you level up, you 
 gain skill points according to your "Skill Point Gain". Note about gaining skill 
-points: you have a max of 50 points in any one Skill. Also, you have a max of 
-17+3*[CHA] points in any one Charisma Skill.
+points: you have a max of 50 points in any one Skill.
 
 ===== Nanites =====
 


### PR DESCRIPTION
Exchanged defunct Awareness and Search skills with Investigation and Spotting
Replaced "lockpicking" example with "sleight of hand"
Changed Leveling-up table to reflect that Skill point gain is determined by int OR cha
Moar Awareness scrubbing
Taking 50/100 clarity pass
Removed a reference to purchasing skills at 10 pts
Changed 10 pts/lvl limit to 5
Deleted a  now-invalid line re: melee and stealth
Changed the section on rolling without skill to reflect my skills philosophy
Reworked Skill Proficiency paragraph
Deleted the second repetition that tying the DC=fail
Deleted references to "melee combat skill" pending melee rework
[failed a will save against correcting language outside the scope of this pr]