### PR TITLE
Turtlelord26 Melee 2.1 Melee Weapon Categorization

### DIFF
--- a/CharacterCreation/02_Classes.txt
+++ b/CharacterCreation/02_Classes.txt
@@ -399,7 +399,6 @@ Passives:
 * Gain Skill Survival at 10.
 * Gain Feat: Proficiency: Light Melee Weaponry.
 * Gain Feat: Proficiency: One-handed Melee Weaponry.
-* Gain Feat: Proficiency: Polearm Melee Weaponry.
 * Purchase your first primary cloaking module at a $1500 discount
 * Cloaking's Nanite Activation cost is reduced by 4 after level 3
 * Gain Ability "Mark Quarry" Detailed below

--- a/CharacterCreation/02_Classes.txt
+++ b/CharacterCreation/02_Classes.txt
@@ -23,7 +23,9 @@ Starting Wealth: $3770 + 100*Luck
 
 Passives: 
 * Gain Skill Weapons - [Choose one] at 10.
-* Gain a +15 to Rolls for initiative. (You go first more often).
+* Gain a +15 to Rolls for initiative (You go first more often).
+* Gain Feat: Proficiency: Light Melee Weaponry.
+* Gain Feat: Proficiency: One-handed Melee Weaponry.
 
 Weapon Proficiencies: 
 * Pistols 
@@ -90,6 +92,7 @@ Starting Wealth: $4150 + 100*Luck
 Passives: 
 * Gain Skill Weapons - Thrown OR Weapons - Explosives at 10.
 * Gain Skill Weapons - Heavy at 10.
+* Gain Feat: Proficiency: Light Melee Weaponry.
 
 Weapon Proficiencies: 
 * Pistols
@@ -149,6 +152,7 @@ Passives:
 * Gain Skill Knowledge - Xenology at 5.
 * Gain Skill Knowledge - [Choose one] at 5.
 * Gain Skill Medicine at 10. 
+* Gain Feat: Proficiency: Light Melee Weaponry.
 
 	Every level, you gain one skill in both of the "Hippocratic" and 
 "Malpractice" skill trees. At level 1 you start with an arm mounted needle 
@@ -205,6 +209,7 @@ Starting Wealth: $2580 + 100*Luck
 passives: 
 * Gain Skill Repair at 10.
 * Gain Skill Jury-rigging at 10.
+* Gain Feat: Proficiency: Light Melee Weaponry.
 * 2 Control Points
 * 600 Maximum Energy
 * 1000 Maximum Material
@@ -284,6 +289,7 @@ Starting Wealth: $2750 + 100*Luck
 Passives: 
 * Gain Skill Hacking at 10.
 * Gain Skill Knowledge - Computers at 10.
+* Gain Feat: Proficiency: Light Melee Weaponry.
 
 Weapon Proficiencies: 
 * Pistols
@@ -334,7 +340,9 @@ Class Primary Attribute: Dexterity
 Starting Wealth: $2670 + 100*Luck
 
 Passives: 
-* Gain Skill Vehicles - [Choose two] at 10.
+* Gain Skill Vehicles - [Choose one] at 10.
+* Gain Skill Vehicles - [Choose another] at 10.
+* Gain Feat: Proficiency: Light Melee Weaponry.
 
 At level 6, the Feat ". . . Who Needs Nano-Technologies" is automatically unlocked.
 
@@ -350,7 +358,8 @@ Armor Proficiencies:
 * Medium.
 
 Skill Proficiencies:
-* Vehicles - [Choose two]
+* Vehicles - [Choose one]
+* Vehicles - [Choose another]
 * Weapons - General
 
 == Class Feats ==
@@ -388,6 +397,9 @@ Starting Wealth: $3290 + 100*Luck
 Passives: 
 * Gain Skill Spotting at 10.
 * Gain Skill Survival at 10.
+* Gain Feat: Proficiency: Light Melee Weaponry.
+* Gain Feat: Proficiency: One-handed Melee Weaponry.
+* Gain Feat: Proficiency: Polearm Melee Weaponry.
 * Purchase your first primary cloaking module at a $1500 discount
 * Cloaking's Nanite Activation cost is reduced by 4 after level 3
 * Gain Ability "Mark Quarry" Detailed below
@@ -516,6 +528,9 @@ Class Primary Attribute: Perception
 Starting Wealth: $1975 + 100*Luck
 
 Passives: 
+* Gain Skill Acrobatics at 10
+* Gain Skill Weapons - Pistol at 10
+* Gain Feat: Proficiency: Light Melee Weaponry
 * Gain Feat: Predictive Gun-fighting
 * Gain 2 Pistol Bonuses
 * Gain 1 Pistol Weakness
@@ -585,6 +600,7 @@ Feats:
 	reduced to a max of 30m. If you run out of rounds, you may reload mid-kata 
 	by passing a DC 75 DEX check. If a target dies by one of your attacks,
 	gain +1 additional attack.
+
 ======================================
 
 =====   ASSASSIN   =====
@@ -599,6 +615,9 @@ Starting Wealth: $1975 + 100*Luck
 Passives:
 * No penalty for engaging in Grappling maneuvers.
 * Gain Skill Weapons - Melee at 10
+* Gain Skill Stealth at 10
+* Gain Feat: Proficiency: Light Melee Weaponry.
+* Gain Feat: Proficiency: One-handed Melee Weaponry.
 * Gain bonus cloaking time when using other cloaking devices besides the Shadow Cloak.
 
 	Assassins wear a Shadow Cloak, which allows them to become a mere silhouette.
@@ -669,6 +688,7 @@ Starting Wealth: $3190 + 100*Luck
 Passives:
 * Gain Skill Weapons - Long Rifles at 10.
 * Gain Skill Spotting at 10.
+* Gain Feat: Proficiency: Light Melee Weaponry.
 * Gain feat "Skilled Overwatch": Held firing actions have +20 bonus damage.
 
 Weapon Proficiencies:
@@ -725,7 +745,7 @@ Skill Profiencies:
 		Denial of Service: Does not deal damage. Half of your standard damage may be used as a bonus% to a friendly Priest's hack 
 ======================================
 
-=====   BESERKER   =====
+=====   BERSERKER   =====
 	As an aficionado of the combat arts, you understand how important tactile 
 feedback is. Guns simply don't offer the appropriate amount, which is why you 
 prefer to BEAT YOUR ENEMIES TO DEATH USING YOUR BARE HANDS WHENEVER 
@@ -735,7 +755,12 @@ Class Primary Attribute: Strength
 Starting Wealth: $2170 + 100*Luck
 
 Passives:
-* Gain Feat: Unarmed Combat Training
+* Gain Skill Weapons - Melee at 10.
+* Gain Skill Athletics at 10.
+* Gain Feat Unarmed Combat Training.
+* Gain Feat: Proficiency: Light Melee Weaponry.
+* Gain Feat: Proficiency: One-handed Melee Weaponry.
+* Gain Feat: Proficiency: Two-handed Melee Weaponry.
 
 Weapon Proficiencies:
 * Pistols.

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -415,9 +415,8 @@ includes this common noun in its name. This feat may be learned multiple times.
 
 	If a particular Exotic melee weapon would require two hands to effectively 
 wield, a character must have Proficiency with two-handed melee weapons to learn this 
-feat for that weapon type. The same applies to Polearm-style, One-handed style, and 
-Light-style exotic weapons, all of which are specified in Exotic weapons' Size stat 
-as a subtype.
+feat for that weapon type. The same applies to One-handed style and Light-style 
+exotic weapons, all of which are specified in Exotic weapons' Size stat as a subtype.
 
 == Proficiency: Light Melee Weaponry ==
 
@@ -425,13 +424,6 @@ Prerequisites:
 * None
 
 	Allows a character to use Melee weapons of size Light.
-
-== Proficiency: Polearm Melee Weaponry ==
-
-Prerequisites: 
-* Proficiency: Light Melee Weaponry
-
-	Allows a character to use Melee weapons of size Polearm.
 
 == Proficiency: One-handed Melee Weaponry ==
 

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -402,6 +402,51 @@ Prerequisites:
 	Whenever you are facing someone you are aware of, and they enter into adjacency
 with you, you gain a preemptive melee strike against them.
 
+== Proficiency: Exotic Melee Weaponry ==
+
+Prerequisites:
+
+* Special, see below.
+
+	Allows a character the ability to use one particular type of Melee weapon 
+of size Exotic. Choose one common noun that is not a damage type each time you 
+learn this feat; that noun is the type. You may use any Exotic melee weapon that 
+includes this common noun in its name. This feat may be learned multiple times.
+
+	If a particular Exotic melee weapon would require two hands to effectively 
+wield, a character must have Proficiency with two-handed melee weapons to learn this 
+feat for that weapon type. The same applies to Polearm-style, One-handed style, and 
+Light-style exotic weapons, all of which are specified in Exotic weapons' Size stat 
+as a subtype.
+
+== Proficiency: Light Melee Weaponry ==
+
+Prerequisites:
+* None
+
+	Allows a character to use Melee weapons of size Light.
+
+== Proficiency: Polearm Melee Weaponry ==
+
+Prerequisites: 
+* Proficiency: Light Melee Weaponry
+
+	Allows a character to use Melee weapons of size Polearm.
+
+== Proficiency: One-handed Melee Weaponry ==
+
+Prerequisites:
+* Proficiency: Light Melee Weaponry
+
+	Allows a character to use Melee weapons of size One-handed.
+
+== Proficiency: Two-handed Melee Weaponry ==
+
+Prerequisites: 
+* Proficiency: One-handed Melee Weaponry
+
+	Allows a character to use Melee weapons of size Two-handed.
+
 == Quickdraw ==
 
 Prerequisites:

--- a/CharacterCreation/04_01_Melee_&_Thrown_Weapons.txt
+++ b/CharacterCreation/04_01_Melee_&_Thrown_Weapons.txt
@@ -8,7 +8,30 @@ and any relevant feat or skill bonuses to oppose your opponent's
 Guard Class, or GC. Melee weapons do not pierce armor, unless otherwise 
 stated.
 
-===== UNARMED FIGHTING =====
+	Melee weapons come in one of five size categories. The first 
+four are Light, One-handed, Two-handed, and Polearms. Characters start 
+with proficiency with some number of these based on their class. The 
+fifth category is Exotic. Acquiring proficiency with Exotic weapons does 
+not grant access to all Exotic weapons, but rather to a particular type, 
+such as whips. Exotic proficiencies may rarely be granted by Backgrounds, 
+and are more commonly acquired by feat.
+
+	When a Two-handed weapon uses a character's STR mod in its damage 
+calculation and the character's STR mod is positive, that character instead 
+uses 150% of their STR modifier to calculate damage.
+
+	Some One-handed weapons have the Hybrid size property. Characters 
+with proficiency with Two-handed melee weapons may make two-handed strikes 
+with these weapons, which allows them to add their STR modifier as if 
+the weapon was Two-handed.
+
+	Unarmed Strike is not a weapon and therefore does not have a 
+size category. All characters are considered proficient with Unarmed 
+Strike. Efficacy is an entirely separate issue.
+
+==============================
+UNARMED
+==============================
 
 == Unarmed Strike ==
 
@@ -25,6 +48,7 @@ MELEE WEAPONS
 == Eliazar Plasma Torch $240 ==
 
 Damage: 30 + 2x Plasma Burn
+Size: Light
 Range: Adjacent (1m)
 Accuracy Modifier: +1
 STR Requirement:   3
@@ -32,9 +56,10 @@ STR Requirement:   3
 	Plasma. Can quickly repair vehicles with welding materials, seal/cut through 
 moderate doors, and make temporary cover. -40% stealth for being quiet on stealth attacks.
 
-== Gurbur G1 Combat Knife $315 ==
+== Gurber G1 Combat Knife $315 ==
 
 Damage: 40 + STR + 2*DEX + 1xBleed
+Size: Light
 Range: Adjacent (1m)
 Accuracy Modifier: +1
 DEX Requirement: 3
@@ -42,6 +67,7 @@ DEX Requirement: 3
 == Gurber GS101 Combat Sword $680 ==
 
 Damage: 50 + 2*STR + 2*DEX + 1xBleed
+Size: One-handed
 Range: 2m
 Accuracy Modifier: +2
 DEX Requirement: 4
@@ -51,6 +77,7 @@ DEX Requirement: 4
 == Guri Grabber Knife $470 ==
 
 Damage: 30 + STR + 2*DEX + 1xBleed
+Size: Light
 Range: Adjacent (1m)
 Accuracy Modifier: +1
 DEX Requirement: 5
@@ -62,18 +89,19 @@ grappling checks. Whenever you roll a successful grappling check, you may deal
 == Guri Carbon Whip $560 ==
 
 Damage: 30 + 3*STR + 2*DEX
+Size: Exotic - One-handed
 Range: 3m
 Accuracy Modifier: +1
 DEX Requirement: 6
 
-	Requires "Weapon Use [Exotic]". Can grapple limbs from range (DEX based 
-grapple) and force movement (1m for every 5 [DEX or STR]). Can disarm weapons 
-from range according to Hand-to-Hand [trained] or [Expert] disarm rules (you 
-must have [Trained] or [Expert] to use their respective rules).
+	Can grapple limbs from range (DEX based grapple) and force movement 
+(1m for every 5 [DEX or STR]). Can make Disarm attempts at range. Grapple, 
+Shove, and Disarm attempts with the whip costs Actions as normal.
 
 == SPECO SP10 VAE Combat Knife $640 ==
 
 Damage: 45 + STR + 2*DEX + 1xBleed
+Size: Light
 Range:  Adjacent (1m)
 Accuracy Modifier: +1
 DEX Requirement: 4
@@ -83,6 +111,7 @@ DEX Requirement: 4
 == SPECO SPC50 VAE Circular Saw $695 ==
 
 Damage: 55 + STR + 1xBleed
+Size: Two-handed
 Range: Adjacent (1m)
 Accuracy Modifier: +1
 STR Requirement: 4
@@ -94,6 +123,7 @@ this weapon.
 == SPECO SP30 VAE Combat Sword $1245 ==
 
 Damage: 55 + 2*STR + 2*DEX + 1xBleed
+Size: One-handed
 Range: 2m
 Accuracy Modifier: +2
 DEX Requirement: 6
@@ -105,11 +135,12 @@ DEX Requirement: 6
 == Eliazar E500 Assisted-Sledgehammer $811 ==
 
 Damage: 50 + 6*STR
+Size: Two-handed
 Range: 2m
 Accuracy Modifier: +0
 STR Requirement: 6
 
-	2-handed weapon. Considered concussive (explosive) damage. Hits armor points 
+	Considered concussive (explosive) damage. Hits armor points 
 before physical damage if the target's armor has defense against explosive (i.e. 
 concussive) damage. If armor roll is greater than 50%, target rolls a DC 50% 
 fort save for a broken limb of your choice. -20% stealth rolls for being quiet 
@@ -118,6 +149,7 @@ on stealth attacks. Reduces door-breaking DC by 30% per hit.
 == Eliazar E5500 Power Fist $880 ==
 
 Damage: 50 + 5*STR
+Size: Light
 Range: Adjacent (1m)
 Accuracy Modifier: +1
 STR Requirement: 5
@@ -131,51 +163,55 @@ door-breaking DC by 45% per hit.
 == Muzashi VAE Katana $1354 ==
 
 Damage: 60 + STR + 3*DEX + 2xBleed
+Size: One-handed - Hybrid
 Range: 2m
 Accuracy Modifier: +2
 DEX Requirement: 6
 
-	Requires "Weapon Use [Exotic]". Voltage Aligned Edge; ignores standard armor.
+	Voltage Aligned Edge; ignores standard armor.
 
 == Eliazar Plasma Sword $987 ==
 
 Damage: 50 + STR + 2*DEX + 3xPlasma Burn
+Size: One-handed
 Range: 2m
 Accuracy Modifier: +2
 DEX Requirement: 4
 
-	Requires "Weapon Use [Exotic]". Plasma effect reduces armor by 1 level as 
-usual, but this effect applies during the sword hit (instead of after). If the 
-target has a standard (non-Nanite) shield, all plasma burn is canceled, the 
-shield takes 30 damage and the plasma sword passes through the shield.
+	Plasma effect reduces armor by 1 level as usual, but this effect applies 
+during the sword hit (instead of after). If the target has a standard 
+(non-Nanite) shield, all plasma burn is canceled, the shield takes 30 damage and 
+the plasma sword passes through the shield.
 
 
 ==============================
-MISCELLANEOUS THROWN WEAPONS
+THROWN WEAPONS
 ==============================
 
 	These weapons work similarly to guns. However your range is determined by 
 your DEX or STR and your miss chance is reduced by your [Combat PER Mod]. Like 
 melee attacks, if you roll a Crit or 3+ above your Miss Chance, you ignore the 
-target's armor and deal full damage. Misc thrown weapons also benefit from Stealth 
+target's armor and deal full damage. Thrown weapons also benefit from Stealth 
 Attacks (see basic rules).
 
 	Thrown weapons benefit from half the base damage bonuses from Unarmed Combat 
 feats.
 
-	Also, If you have Weapons - Thrown skill >=20 then all DEX or STR requirements 
-for Misc. Thrown Weapons are reduced by 1.
+	If you have Weapons - Thrown skill >=20 then all DEX or STR requirements 
+for Thrown Weapons are reduced by 1.
 
 	All misc thrown weapons have a Reflex Modifier: -10
-
-	(When dividing Thrown Weapon Skill, drop the remainder)
-
+	
+	Thrown weapons use the same size categories as Melee weapons for 
+determining proficiency, though a Two-handed throwing weapon would be 
+rare indeed.
 
 ===== LEVEL 1 REQUIREMENT WEAPONS =====
 
 == Gurber Throwing Knife $80 ==
 
 Damage: 15 + STR + DEX + [Thrown Weapon Skill]/2 + 1xBleed
+Size: Light
 DEX Requirement: 5
 AP Level: 2
 
@@ -191,6 +227,7 @@ AP Level: 2
 == EAL Tactical Throwing Axe $160 ==
 
 Damage: 25 + 3*STR + DEX + [Thrown Weapon Skill]/2 + 1xBleed
+Size: Light
 STR Requirement: 5
 AP Level: 3
 
@@ -207,6 +244,7 @@ Secondary Ammo Slot.
 == Carbide Kunai $120 ==
 
 Damage: 25 + STR + DEX + [Thrown Weapon Skill]/2 + 1xBleed
+Size: Light
 DEX Requirement: 6
 AP Level: 4
 
@@ -221,6 +259,7 @@ When thrown, +30% to stealth rolls to hide the attack.
 == Plasma Catalyst Kunai $160 ==
 
 Damage: 10 + STR + DEX + [Thrown Weapon Skill]/2 + 3xPlasma Burn
+Size: Light
 DEX Requirement: 6
 AP Level: 5
 

--- a/CharacterCreation/04_01_Melee_&_Thrown_Weapons.txt
+++ b/CharacterCreation/04_01_Melee_&_Thrown_Weapons.txt
@@ -30,11 +30,19 @@ with these weapons, which allows them to add their STR modifier as if
 the weapon was Two-handed (see the preceeding paragraph). Such a strike 
 must be declared to be two-handed before rolling to hit, and the character 
 doing so loses the benefits of any items that require his or her off hand to 
-function.
+function.*
 
 	Unarmed Strike is not a weapon and therefore does not have a 
 size category. All characters are considered proficient with Unarmed 
 Strike. Efficacy is an entirely separate issue.
+
+*As an example, a character with a STR mod of 8 is attacking an enemy with a 
+hammer of size One-handed - Hybrid that deals 40 + STR mod damage. Before 
+rolling the attack, the player may declare that the character is making a 
+two-handed strike, which will increase the damage from 40 + 8 = 48 to 
+40 + (8 * 1.5) = 40 + 12 = 52. If that character was holding a weapon or 
+defensive implement in his or her off-hand, that item cannot be used and 
+it provides no bonuses for one round.
 
 ==============================
 UNARMED

--- a/CharacterCreation/04_01_Melee_&_Thrown_Weapons.txt
+++ b/CharacterCreation/04_01_Melee_&_Thrown_Weapons.txt
@@ -8,8 +8,8 @@ and any relevant feat or skill bonuses to oppose your opponent's
 Guard Class, or GC. Melee weapons do not pierce armor, unless otherwise 
 stated.
 
-	Melee weapons come in one of five size categories. The first 
-four are Light, One-handed, Two-handed, and Polearms. Characters start 
+	Melee weapons come in one of four size categories. The first 
+three are Light, One-handed, Two-handed. Characters start 
 with proficiency with some number of these based on their class. The 
 fifth category is Exotic. Acquiring proficiency with Exotic weapons does 
 not grant access to all Exotic weapons, but rather to a particular type, 

--- a/CharacterCreation/04_01_Melee_&_Thrown_Weapons.txt
+++ b/CharacterCreation/04_01_Melee_&_Thrown_Weapons.txt
@@ -18,12 +18,19 @@ and are more commonly acquired by feat.
 
 	When a Two-handed weapon uses a character's STR mod in its damage 
 calculation and the character's STR mod is positive, that character instead 
-uses 150% of their STR modifier to calculate damage.
+uses 150% of their STR modifier to calculate damage. For example, if some 
+two-handed weapon dealt damage equal to 40 + 2xSTR nod and the character 
+wielding it had a STR mod of -4, each strike would deal 32 = 40 + (-4 * 2) 
+damage. A character with the same weapon and a STR mod of 12 would deal 
+76 = 40 + ((12 * 1.5) * 2) = 40 + (18 * 2) damage per strike.
 
 	Some One-handed weapons have the Hybrid size property. Characters 
 with proficiency with Two-handed melee weapons may make two-handed strikes 
 with these weapons, which allows them to add their STR modifier as if 
-the weapon was Two-handed.
+the weapon was Two-handed (see the preceeding paragraph). Such a strike 
+must be declared to be two-handed before rolling to hit, and the character 
+doing so loses the benefits of any items that require his or her off hand to 
+function.
 
 	Unarmed Strike is not a weapon and therefore does not have a 
 size category. All characters are considered proficient with Unarmed 


### PR DESCRIPTION
Solves Issue #411 

I have added 5 Size categories of Melee Weapon: Light, One-handed, Two-handed, Polearm, and Exotic. The first four work like gun categories for proficiency purposes, Exotic is more special and applies to categories like "whip" or "flail". 
Also took a first pass on giving the various classes baseline melee proficiencies. Some class passives were scope-creeped on during this process, see commit notes. A couple of explains:
-Assassin only gets the smaller ones because that's their aesthetic
-Hunters get polearms because hunting and one-handed because machetes.
Finally, there are feats now for expanding individual characters' melee repertoires. 