### PR TITLE
More Skills consistency

### DIFF
--- a/01_01_Basic_Rules.txt
+++ b/01_01_Basic_Rules.txt
@@ -326,7 +326,7 @@ perception makes you harder to sneak up on.
 
 	If you have 1 Perception, you are partially blind, only have 1 eye, or
 something similar. You cannot use the Investigation or Spotting skills and you have a 
--20 malus to Speech skill rolls. 
+-20 malus to Insight skill rolls. 
 
 Fortitude (FORT): 
 	How tough are you? Fortitude determines your maximum health, how hard you 
@@ -384,7 +384,7 @@ body like climbing, jumping, or dancing.
 	If you have 1 Dexterity, you are especially clumsy or suffer from a 
 debilitating illness which affects your ability to move swiftly and precisely. 
 You cannot learn any skills that use Dexterity as the contributing stat (for 
-example, Slight of Hand).
+example, Sleight of Hand).
 
 Luck (LUCK): 
 	Some people are just lucky! A GM will often have you roll luck to see if a 
@@ -430,9 +430,12 @@ Ability and 6m of movement speed penalties, you end up with no movement speed
 penalties.
 
 Skill Point Gain:
-	How many skill points you gain every level. Every time you level up, you 
-gain skill points according to your "Skill Point Gain". Note about gaining skill 
-points: you have a max of 60 points in any one Skill.
+	Determines wow many skill points you gain every level. Every time you level up, you 
+gain skill points according to your "Skill Point Gain". You may gain a maximum of
+60 skill points in a single skill. In addition, each time you level up, you may gain a
+maximum of 6 points in any one skill by using your Skill Point Gain. Skill gained from
+Feats and Class passives counts towards the maximum of 60 points per skill, but not
+towards the maximum skill increase per level.
 
 ===== Nanites =====
 
@@ -479,8 +482,9 @@ in combat and can purchase weapons of that type in the world or during character
 creation. If your Character lacks proficiency with a weapon, then they can't 
 purchase or use a weapon of that type. 
 
-	Note that Weapon Proficiency is different than having Skills with that 
-weapon. For more on Skills, see the "RP / Using Skills" section of this document.
+	Note that Weapon Proficiency is different from having Proficiency with the
+Skill Weapon - [X]. For details on Skill Proficiencies and Weapon SKills, see the
+"RP/Using Skills" section or the Skills document.
 
 ===== Armor Proficiencies =====
 
@@ -501,9 +505,9 @@ totals, not to be added together. Every 5th level, +1 Class feat.
 	Every level, gain 2*(Skill Point Gain) skill points.
 
 	On levels 5, 9, 15 and 20, gain a stat point. The stat increase happens 
-before any calculations, so if you had 10 int, and increased to 11, you would 
-get 22 skill points for the level. Additionally, any stat point alteration 
-forces a recalculation on all affected values.
+before any calculations, so if you had 10 INT, and increased to 11, you would 
+make any necessary changes to your Skill Point Gain before gaining and assigning
+skill points for that level.
 
 ===== LEVELING-UP TABLE =====
 
@@ -579,11 +583,11 @@ Healing Injuries
 	Ouch! you've just been shot! You'd better call for a Doctor or apply a med 
 kit before you bleed out! "But how do I use a med kit? Or if I'm a Doctor, how 
 do I stabilize and heal an ally?" I'm glad you asked. The rules are as follows:
-The Medicine DC is equal to the damage dealt. On a fail skill check, no healing 
+The Medicine DC is equal to the damage dealt. On a failed skill check, no healing 
 occurs. On a success, heal an amount equal to Medicine skill + DC surplus.
 
 	For example, a Player Character is dealt 70 damage. Their Doctor has 25 
-skill in medicine. Medic rolls an 86 (after adding the Medicine Skill), so they 
+skill in medicine. Medic rolls an 86 (after adding their Medicine Skill), so they 
 heal 25+(86-70) for 41 health healed.
 
 	Individual wounds are healed individually. 3x 20-damage wounds need three 
@@ -599,7 +603,7 @@ a wound unless otherwise stated).
 equivalent) on their person. If they do not have their medicine bag with them 
 when they are trying to heal a teammate, they can make the attempt at a +20 DC.
 
-Using a medikit:
+Using a medic-kit:
 
 	Medic-kit, non-medic user: works as if you are a medic with skill 30.
 
@@ -636,13 +640,12 @@ health. Any additional attacks you sustain will push you into negative health.
 
 Stabilize:
 	As an action, a teammate may bring you back up to 1 health point by succeeding 
-on a Medicine skill check to stabilize you. Once stabilized, you may take actions 
-and speak as normal. Don't forget that a recently stabilized character may need 
-to take an action to retrieve a dropped weapon and/or take an action to stand 
-back up if you have fallen.
+on a DC 80 Medicine skill check to stabilize you. Medicine skill, INT mod, and any
+bonuses from medical equipment such as medic-kits are added to the roll. Once stabilized,
+you may take actions  and speak as normal.
 
-	The skill DC to stabilize a fallen comrade is 80. Medicine skill, INT mod, 
-and any bonuses from medical equipment such as medpacks may be added to that roll. 
+	Don't forget that a recently stabilized character may need  to take actions to
+retrieve a dropped weapon or stand back up if they have fallen.
 
 *Some hazards can reduce you to zero health points and kill you 
 instantly. Some examples are falling several stories, lava baptisms,
@@ -671,34 +674,34 @@ something. This may be something like, "Roll Sleight of Hand to see if you can
 pick the lock on that door," or it might look like, "Roll Medicine to see if 
 you can patch up the gaping wound in your chest spewing blood." Anytime you 
 need to Pass a Skill check, there will be a DC (Difficulty Check) you have to 
-exceed in order to successfully pass the check. Again: YOU MUST ROLL *OVER* A DC 
-TO SUCCEED IN A SKILL CHECK. the DC does not need to be given out by the GM, but if
+exceed in order to successfully pass the check. You must roll over the DC to
+succeed at a check. The DC does not need to be given out by the GM, but if
 a DC seems too high, you have the right to grumble (but seriously, ask your GM if 
 something seems too difficult. There is usually a reason why tying your shoe 
 takes a DC of 70% on that particular day, etc). After you have rolled, please
-apply any and all relevant skills to your result. Also add any relevant Stat Bonuses
-to a roll. When rolling investigation, add your PER Bonus, etc.
+apply any and all relevant skills and Stat Bonuses to a roll, as instructed by your GM.
+When rolling Investigation for example, you will likely add your PER Stat Bonus.
 
 	At any time out of combat, you may decide to use one of your skills. If you 
-are not pressured by imminent / immediate danger, you may "take a 100%" to take your
-time with a task to roll exactly 100 on a skill check, then apply any ranks in the
-skill. 
-	When rushed by a time constraint or danger, you can "take a 50%" to take
+are not pressured by imminent or immediate danger, you may "take a 100%" to take as
+much time with a task as needed to roll exactly 100 on a skill check, then apply points
+from relevant skills and Stat Bonuses. Some checks cannot be passed in this way. Under
+normal circumstances for example, you will not be able to pass an Athletics check to
+kick down the blast doors of a ship, no matter how much time you take to try.
+
+When rushed by a time constraint or danger, you can "take a 50%" to take
 slightly more time than a 1-action, in-combat check on a task to roll exactly 50 on
-a skill check, then apply any ranks in said skill. However, some checks cannot be
-passed in this way. If you are staring at a ship's blast doors, and want to kick
-them down, you can't take additional time to increase your odds of success.
+a skill check, then apply any skill points and Stat Bonuses.
 
 	If you want to use a skill in combat, see the "Combat: Actions" subsection.
-Skill ranks are exact percentiles to pass a skill check. If you have 50 ranks 
-in a skill, then you have a +50% chance to pass a skill check for that skill. 
-When leveling up you may add up to 5 points to any skill.
-
+	
 	In many cases, a character can attempt a skill check whether or not they
 have invested in learning the skill; however, your GM may decide otherwise, apply
 penalties to your roll, raise the DC, ask you to justify why your character can
 attempt the roll, or make any other judgement they deem appropriate. 
 
+	When leveling up you may gain up to 6 points in any one skill.
+	
 	Characters are considered to be Proficient with certain skills, based on
 their class and background. When a character is Proficient in a skill, each skill 
 point they spend in that skill upon leveling up increases that skill by two 
@@ -794,8 +797,7 @@ grappling player. During grappling, both sides roll opposing grapple checks to
 see who maintains control. Once you have control you may make a grapple check 
 to subdue your opponent (by choke-out, pin, or a joint lock). You may also strike
 an opponent during grappling, but if the strike fails your opponent may attempt 
-to gain control of the grapple. Skill in grappling is different than skill in 
-unarmed combat.
+to gain control of the grapple.
 
 Kicking/Shoving:
 	Instead of dealing full damage, a character can try to kick/shove a human sized
@@ -1028,7 +1030,7 @@ of 7-10 would be successful.
 Gun Jams:
 	If at any time that you are firing a gun and you roll a weapon accuracy of 1,
 roll a second d10. If that second d10 roll is a 1 or 2, the weapon Jams, 
-necessitating a Weapon [X] skill check, DC 60.
+necessitating a Weapon - [X] Skill check, DC 60.
 
 Hip Firing:
 	Add 3 to a weapon's miss chance. You cannot use optical attachments in hip 
@@ -1088,7 +1090,7 @@ Reloading:
 	When a gun runs out of ammunition, the user must pause to reload. "But how 
 long do I gotta be outta the battle?" Great question!
 
-	Each gun has a "Reload DC," rated based on the skill and brevity of the 
+	Each gun has a "Reload DC," rated based on the complexity and brevity of the 
 weapon's reload. For example, an assault rifle, which has a very obvious 
 magazine release button and protruding magazine, has an average DC of 30%. More 
 complex weapons, such as high-precision sniper systems or exotic sub-machine 
@@ -1096,7 +1098,7 @@ guns might have a higher DC, maybe 40%. If the Player passes the reload, then
 the reload time is standard. For Box-Magazine fed Semi- and Fully-Automatic 
 weapons, this is 2 Actions. Other, more complex weapons will specify their 
 reload time. On a critical reload success (affected by luck as normal, anything 
-in the 90-100 range caused by a raw roll or by adding your Weapon [X] skill),
+in the 90-100 range caused by a raw roll or by adding your Weapon - [X] skill),
 the reload time is halved (for Bolt-Actions it is reduced to 1 Action). On a 
 failure, the reload time takes twice as long.
 
@@ -1274,23 +1276,6 @@ one injury, depending on the severity of the fall. Some examples are below:
 * Broken everything
 
 ==============================
-Casting Spells
-==============================
-
-	There are a few classes which are able to cast spells, Paladins, Mages and 
-Sorcerers. Casting spells is very similar to performing other actions. 
-Normally, a spell takes one action to cast. The performer of the spell will 
-have to pass a Skill DC in order to successfully cast the spell. This DC is 
-the number of Nanites used to cast the spell, plus an bonuses the target gains 
-from cover. For Mages and Sorcerers this is a Spellcast DC, and for Paladins 
-this is a Knowledge [Nanites] DC. Mages/Sorcerers can add any skill points 
-they have in Sorcery to their rolls, and Paladins may do the same with their 
-Knowledge [Nanites] skill. Some spells may also require the target to make a 
-saving throw in order to avoid the spell or negate its effects. Generally 
-speaking, spells have a range that is dependent on either the Charisma score 
-of the caster or the Charisma Modifier.
-
-==============================
 Cloaking
 ==============================
 
@@ -1316,15 +1301,15 @@ able to cloak again.
 ===== Cloaking Detection =====
 
 	If someone/something is looking for you, they must pass a (normally, 
-perception) check at 'Detect DC' difficulty, modified by your stealth skill. 
-While moving, the detect DC is reduced (listed as 'moving detect DC' under the 
+perception) check at 'Detect DC' difficulty, modified by your Stealth skill. 
+While moving, the Detect DC is reduced (listed as 'moving Detect DC' under the 
 relevant cloaking module's description). There is a tell-tale shimmer in the 
 cloak, as the micro-foil has a hard time keeping up with moving environments. 
 Once the wearer has settled down, the micro-foil is able to reproduce the 
 surrounding environment better and will stabilize.
 
 	When using a skill (accessing a terminal, fixing something, etc.) use your 
-reduced, 'moving detect DC' as you are diverting your attention. However, once 
+reduced, 'moving Detect DC' as you are diverting your attention. However, once 
 you have performed a combat action, the cloak fizzes out.
 
 ===== CLOAKING DURATIONS AND LEVELING BONUSES =====


### PR DESCRIPTION
In penalty for 1 PER, exchanged Insight with now-defunct Speech.
Various skills-related spelling and grammar edits
Worked on not splitting skills rules into different documents and sections
Clarified the distinction between Weapon Proficiency and Proficiency in Weapon Skills
Clarified an example in Leveling Up to better reflect Secondary Stats
Re-worded passages on Medicine Skill checks for clarity and writing quality
Edited some lines of RP/Using Skills for tone
Nuked unnecessary and confusing lines from RP/Using Skills
Changed max skill increase per level to 6, up from 5 re Issue #458 
Deleted a line about defunct grapple and unarmed combat Skills
Standardized some Skills typography and stylization
Deleted a spellcasting section

Edit: I focused on standardizing typography and diction. Calling it "stylization" was misleading.