### PR TITLE
Balance Pass on Shotgun Expertise

### DIFF
--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -643,8 +643,8 @@ have no prerequisites.
 12:	May use Weapons - Shotgun in place of Acrobatics for checks to execute 
 	a physical maneuver following violent entry of a room.
 24:	If you succeed a reload check by at least 20, reduce the time taken to 
-	reload by one Action, stacking with other reductions (such as from crits), 
-	to a minimum of one Action.
+	reload by one Action, stacking with other reductions (such as from 
+	critical success), to a minimum of one Action.
 36:	Negate the hip-firing Accuracy penalty against enemies within R1 while 
 	firing spreading shot.		
 48:	+10m to range R2. If this would cause R2 to be greater than R3, 

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -613,7 +613,7 @@ have no prerequisites.
 == Pistol Expertise ==	
 
 0:	+5m to ranges R1 & R2. If this would cause R2 to be greater than R3, 
-	also increase R3 to match the new R2.
+	also set R3 equal to the new R2.
 12:	May use Weapons - Pistol in place of Stealth for checks made to prevent 
 	enemies from noticing your Pistol fire.
 24:	Reduce the Reload check penalty imposed by the Dual-Wield / Akimbo feats 
@@ -626,7 +626,7 @@ have no prerequisites.
 == Submachine Gun Expertise ==
 
 0:	+5m to ranges R1 & R2. If this would cause R2 to be greater than R3, 
-	also increase R3 to match the new R2.
+	also set R3 equal to the new R2.
 12:	May use Weapons - SMG in place of Intimidate for checks to intimidate 
 	a target you are suppressing with an SMG.
 24:	+10 Gun Reflex to one SMG you are wielding.
@@ -638,12 +638,20 @@ have no prerequisites.
 
 == Shotgun Expertise  ==
 
-0:	+10m to range R3	
-12:	-15% reload miss chance			
-24:	+5 Gun Reflex				
-36:	-0.5 miss chance @ all ranges			
-48:	+10% perception checks for awareness within 25m.			
-60:	+10% Base damage. If you hit armor with a higher APL than your shotgun, you deal half damage to its AS instead of no damage (and full damage to health if you deplete the AS).
+0:	+5m to range R1. If this would cause R1 to be greater than R2, 
+	also set R2 equal to the new R1.
+12:	May use Weapons - Shotgun in place of Acrobatics for checks to execute 
+	a physical maneuver following violent entry of a room.
+24:	If you succeed a reload check by at least 20, reduce the time taken to 
+	reload by one Action, stacking with other reductions (such as from crits), 
+	to a minimum of one Action.
+36:	Negate the hip-firing Accuracy penalty against enemies within R1 while 
+	firing spreading shot.		
+48:	+10m to range R2. If this would cause R2 to be greater than R3, 
+	also set R3 equal to the new R3.
+60:	+10% Base damage. If you hit armor with a higher APL than your shotgun, 
+	you deal half damage to its AS instead of no damage (and full damage 
+	to health if you deplete the AS).
 
 == Carbine Expertise ==
 


### PR DESCRIPTION
Shotguns also live in shorter-ranged spaces, but where SMGs spread their damage out among many bullets, Shotguns blast things in more discrete packages of death.
Strengths: point-blank damage spike, spreading vs solid shot versatility, generally high damage
Weaknesses: short-range, single-target, low APLs

0: Range bracket increase applied to R1. Keeping this number low for now because R1 buckshot is terrifyingly high damage.
12: Similarly to how SMGs were specialized by their expertise feat for the suppression role, I'm thinking I will specialize shotguns for room-clearing. To that goal, this bonus replaces Acrobatics for maneuvers while clearing a room, such as diving prone without losing aim on a target.
24: The attempt here is to support the versatility of different shot types by increasing the speed with which one can switch between them. I found no way to gamify '+reload when switching ammo types' so we have to go with flat +reload.
36: Negate hip-firing Accuracy penalty is technically a conditional accuracy buff. More conditional than most, but also pretty powerful and definitely reinforces the room-clearing role. Just subtly enough that people will feel warm and fuzzy for figuring that out, I hope.
48: R2 selected as it is the longest range spreading shot (e.g. buck or flechette) can be fired.
60: Keeping old capstone for now, it's good at alleviateing the APL issue. Will keep an eye on it though because it might be much weaker (or stronger, it's surprisingly hard to armchair evaluate) than the very similar capstone I gave pistols.