### PR TITLE
Balance pass on Carbine & Assault Rifle Expertise

### DIFF
--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -651,9 +651,9 @@ have no prerequisites.
 0:	+10m to range R2. If this would cause R2 to be greater than R3, 
 	also increase R3 to match the new R2.
 12:	May use Weapons - Carbine in place of Acrobatics on checks to maintain balance and negate 
-	combat penalties associated with a vehicle you are on board.
-24:	+25 Weapon Reflex while onboard a vehicle and for 3 rounds after disembarking. +10 Weapon 
-	reflex at other times.
+	combat penalties associated with a vehicle or mount you are on board.
+24:	+25 Weapon Reflex while onboard a vehicle or mount and for 3 rounds after disembarking. 
+	+10 Weapon Reflex at other times.
 36:	+1 Accuracy to ranges R1 and R2 while firing while benefiting from cover of any kind
 	against your target.
 48:	+10m to range R1, +5m to range R3

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -657,7 +657,12 @@ have no prerequisites.
 36:	+1 Accuracy to ranges R1 and R2 while firing while benefiting from cover of any kind
 	against your target.
 48:	+10m to range R1, +5m to range R3
-60:	+10% Base damage; When firing semi-auto mode, +1 crit range
+60:	+10% Base damage; For up to one Action per round you may fire your carbine one-handed with  
+	a -2 Accuracy penalty and double any automatic fire Accuracy penalty. Any foregrips or 
+	other attachments requiring the second hand do not provide their benefits during the 
+	Action, but your offhand is free to do something else. If you have taken aim at a target, 
+	you must succeed on a DC 100 Weapons - Carbine check to maintain that aim during and 
+	through the Action.
 
 == Assault/Battle Rifle Expertise ==
 

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -665,8 +665,9 @@ have no prerequisites.
 	also increase R3 to match the new R2.
 12:	May use Weapons - Assault/Battle Rifle in place of Spotting when looking through your 
 	rifle's scope (warning, takes longer than wider field-of-view optics).
-24:	Halve the jam chance of your assault/battle rifle for the first 3 rounds of its use per 
-	combat, once per short rest (i.e. maintenance & cleaning oportunity).
+24:	Halve the jam chance (applies after additive modifiers, round down, may be zero) of your 
+	assault/battle rifle for the first 3 rounds of its use per combat, once per short rest 
+	(i.e. maintenance & cleaning oportunity).
 36:	+1 Accuracy while firing in burst mode and +2 Accuracy while firing in automatic mode 
 	while benefiting from any kind of cover against your target.
 48:	+5m to range R1, +10m to range R3.

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -643,26 +643,35 @@ have no prerequisites.
 24:	+5 Gun Reflex				
 36:	-0.5 miss chance @ all ranges			
 48:	+10% perception checks for awareness within 25m.			
-60:	+10% Base damage. If you hit armor with a higher APL than your shotgun, you deal half damage to its AS instead of no damage (and full damage to health if you deplete the AS).
+60:	+10% Base damage. If you hit armor with a higher APL than your shotgun, you deal half
+	damage to its AS instead of no damage (and full damage to health if you deplete the AS).
 
 == Carbine Expertise ==
 
-0:	+5m to range R1, +10m to R2 & R3		
-12:	-10% reload miss chance			
-24:	+5 Gun Reflex		
-36:	-0.5 miss chance @ all ranges			
-48:	You can choose to have +5% chance to miss armor when in single fire mode (doesn't apply to 100% coverage armor)	
-60:	+10% Base damage; When firing semi-automatically, +1 crit range
+0:	+10m to range R2. If this would cause R2 to be greater than R3, 
+	also increase R3 to match the new R2.
+12:	May use Weapons - Carbine in place of Acrobatics on checks to maintain balance and negate 
+	combat penalties associated with a vehicle you are on board.
+24:	+25 Weapon Reflex while onboard a vehicle and for 3 rounds after disembarking. +10 Weapon 
+	reflex at other times.
+36:	+1 Accuracy to ranges R1 and R2 while firing while benefiting from cover of any kind
+	against your target.
+48:	+10m to range R1, +5m to range R3
+60:	+10% Base damage; When firing semi-auto mode, +1 crit range
 
 == Assault/Battle Rifle Expertise ==
 
-0:	+5m to range R1, +10m to R2 & R3 
-12:	-10% reload miss chance			
-24:	Automatic Rifles no longer jam			
-36:	-0.5 miss chance @ all ranges			
-48:	-0.5 miss chance when firing in fully-automatic or burst			
-60:	+10% Base damage; May once per turn gain -2 miss chance for a fully-automatic firing action, 
-	This ability can let you bypass the minimum 1 miss chance for automatic firing
+0:	+10m to range R2. If this would cause R2 to be greater than R3, 
+	also increase R3 to match the new R2.
+12:	May use Weapons - Assault/Battle Rifle in place of Spotting when looking through your 
+	rifle's scope (warning, takes longer than wider field-of-view optics).
+24:	Halve the jam chance of your assault/battle rifle for the first 3 rounds of its use per 
+	combat, once per short rest (i.e. maintenance & cleaning oportunity).
+36:	+1 Accuracy while firing in burst mode and +2 Accuracy while firing in automatic mode 
+	while benefiting from any kind of cover against your target.
+48:	+5m to range R1, +10m to range R3.
+60:	+10% Base damage; You may critically hit as normal while firing in burst mode, and may 
+	critically hit with half your normal critical range while firing in automatic mode.
 
 == Long Rifle Expertise ==
 


### PR DESCRIPTION
Carbines and Assault Rifles are possible the most similar pair of weapon types we support, and as such I will label both overall str/wkn and relative str/wkn between the two.
Carbines and Assault Rifles own the Medium range bracket, and are the classic offerings of any cover-based shooter. They make up for their lower range than Long Rifles by spewing their damage faster, particularly making use of burst and automatic fire. Compared to shorter ranged options like shotguns and SMGs, they demonstrate their obvious greater reach alongside better accuracy and sustained rates of steady damage, but are undeniably weaker if enemies can get to R1 ranges.
Strengths: mid-range combat, reliable and high DPS, burst-fire
Weaknesses: CQB, Melee, getting smoked by snipers. That last bit suggests cover-based bonuses.

Carbines differ from assault rifles by, bluntly, being less capable in exchange for being more economical, both financially and in terms of weight. They perform better at shorter medium-length ranges since they can be brought to bear more quickly, but the reduced potency of their ammunition (a requirement for controllable recoil...we'll talk about lasers later. Maybe overheating?) and shorter barrel lengths leave something to be desired in longer-ranged stand-up fights (less damage, range, and APL).

this excerpt from https://en.wikipedia.org/wiki/Carbine#Usage is excellent
> The smaller size and relative lighter weight of carbines makes them easier to handle in close-quarter situations such as urban 
> engagements, when deploying from military vehicles, or in any situation where space is confined. The disadvantages of carbines 
> relative to rifles include inferior long-range accuracy and a shorter effective range. These comparisons refer to carbines (short-barreled 
> rifles) of the same power and class as the regular full-sized rifles.
> 
> Compared to submachine guns, assault carbines have a greater effective range and are capable of penetrating the helmets and body 
> armor used by modern infantrymen.[5] However, submachine guns are still used by military special forces and police SWAT teams for 
> close quarters battle (CQB) because they are "a pistol caliber weapon that's easy to control, and less likely to over-penetrate the 
> target."[5] Also, carbines are harder to maneuver in tight encounters where superior range and stopping power at distance are not 
> great considerations.

Anyway...on to the specific notes
0: Both weapons get R2, as that is where they live.
12: Carbines are being soft-specialized into the weapon of choice for use onboard vehicles, while assault rifles get to be the main-line DPS gun against which every other is measured. Therefore Carbine gets a direct vehicle bonus here. Assault Rifle gets a bonus to precombat maneuvering, with splash damage on general spotting. I was thinking of giving that bonus to long rifles but I decided marksmen should probably be maxing their PER skills anyway and have another fun idea for them [suspense!].
24: Carbines get more vehicle emphasis here. As we noticed with the miniguns, firing tons of bullets dramatically ups the chances of a jam occuring, so Assault rifles get an amelioration to that. Both bonuses just maybe were designed with "Fight Fiercely First" in mind.
36: Carbines are handy at short (relatively, we're not talking shotguns) ranges, so they get their accuracy bonus at R1 and R2. Assault Rifles want their rapid-fire emphasized, so their bonus is during burst or auto fire. The extra bonus for auto fire represents how much better the well-trained soldier is at controlling their weapon than the mostly-trained soldier. I added "from behind cover" riders to encourage positive life decisions...and also because the cover can be used for extra stability if you're fast and trained.
48: Bonuses to both R1 and R3. Carbines get more R1, while Assault Rifles get more R3, as that is what they are better at (though still weaker than their designed point at R2. We follow our own design principles studiously!)
60: Assault rifle automatic accuracy bonus capstone replaced with can-crit-while-rapid-firing rules exception capstone. Luckily can never apply to miniguns.. Let's see if giving our main-line DPS some real teeth adds more tactical role diversity. Ill leave the existing carbine capstone in for now, it creates a nice dichotomy between Carbine "Pew, pew, pew" and assault rifle "pewpewpewpewpewpew".


...wow that's a long one.