### PR TITLE
Rework Long Rifle Expertise

### DIFF
--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -697,7 +697,7 @@ have no prerequisites.
 	single target without losing line of sight to it.
 48:	Halve any minimum range associated with your long rifle and attachments, to a max reduction 
 	of 5m.
-60:	+10% Base damage.Increase by 50% any numerical benefits of specialty ammunition you fire 
+60:	+10% Base damage. Increase by 50% any numerical benefits of specialty ammunition you fire 
 	(does not affect Marksman Tech Rounds feats).
 	
 == Heavy Weapon Expertise ==

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -664,7 +664,7 @@ have no prerequisites.
 36:	+1 Accuracy to ranges R1 and R2 while firing while benefiting from cover of any kind
 	against your target.
 48:	+10m to range R1, +5m to range R3
-60:	+10% Base damage; For up to one Action per round you may fire your carbine one-handed with  
+60:	+10% Base damage. For up to one Action per round you may fire your carbine one-handed with  
 	a -2 Accuracy penalty and double any automatic fire Accuracy penalty. Any foregrips or 
 	other attachments requiring the second hand do not provide their benefits during the 
 	Action, but your offhand is free to do something else. If you have taken aim at a target, 
@@ -683,7 +683,7 @@ have no prerequisites.
 36:	+1 Accuracy while firing in burst mode and +2 Accuracy while firing in automatic mode 
 	while benefiting from any kind of cover against your target.
 48:	+5m to range R1, +10m to range R3.
-60:	+10% Base damage; You may critically hit as normal while firing in burst mode, and may 
+60:	+10% Base damage. You may critically hit as normal while firing in burst mode, and may 
 	critically hit with half your normal critical range while firing in automatic mode.
 
 == Long Rifle Expertise ==
@@ -697,8 +697,8 @@ have no prerequisites.
 	single target without losing line of sight to it.
 48:	Halve any minimum range associated with your long rifle and attachments, to a max reduction 
 	of 5m.
-60:	Increase by 50% any numerical benefits of specialty ammunition you fire (does not affect 
-	Marksman Tech Rounds feats).
+60:	+10% Base damage.Increase by 50% any numerical benefits of specialty ammunition you fire 
+	(does not affect Marksman Tech Rounds feats).
 	
 == Heavy Weapon Expertise ==
 

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -614,7 +614,7 @@ have no prerequisites.
 
 0:	+5m to ranges R1 & R2. If this would cause R2 to be greater than R3, 
 	also set R3 equal to the new R2.
-12:	May use Weapons - Pistol in place of Stealth for checks made to prevent 
+12:	May use Weapons - Pistol (Int) in place of Stealth for checks made to prevent 
 	enemies from noticing your Pistol fire.
 24:	Reduce the Reload check penalty imposed by the Dual-Wield / Akimbo feats 
 	by 10 when dual-wielding pistols.
@@ -627,7 +627,7 @@ have no prerequisites.
 
 0:	+5m to ranges R1 & R2. If this would cause R2 to be greater than R3, 
 	also set R3 equal to the new R2.
-12:	May use Weapons - SMG in place of Intimidate for checks to intimidate 
+12:	May use Weapons - SMG (Cha) in place of Intimidate for checks to intimidate 
 	a target you are suppressing with an SMG.
 24:	+10 Gun Reflex to one SMG you are wielding.
 36:	+2 to Accuracy rolls at all ranges while firing automatically (not burst).
@@ -640,7 +640,7 @@ have no prerequisites.
 
 0:	+5m to range R1. If this would cause R1 to be greater than R2, 
 	also set R2 equal to the new R1.
-12:	May use Weapons - Shotgun in place of Acrobatics for checks to execute 
+12:	May use Weapons - Shotgun (Dex) in place of Acrobatics for checks to execute 
 	a physical maneuver following violent entry of a room.
 24:	If you succeed a reload check by at least 20, reduce the time taken to 
 	reload by one Action, stacking with other reductions (such as from 
@@ -657,7 +657,7 @@ have no prerequisites.
 
 0:	+10m to range R2. If this would cause R2 to be greater than R3, 
 	also increase R3 to match the new R2.
-12:	May use Weapons - Carbine in place of Acrobatics on checks to maintain balance and negate 
+12:	May use Weapons - Carbine (Dex) in place of Acrobatics on checks to maintain balance and negate 
 	combat penalties associated with a vehicle or mount you are on board.
 24:	+25 Weapon Reflex while onboard a vehicle or mount and for 3 rounds after disembarking. 
 	+10 Weapon Reflex at other times.
@@ -675,7 +675,7 @@ have no prerequisites.
 
 0:	+10m to range R2. If this would cause R2 to be greater than R3, 
 	also increase R3 to match the new R2.
-12:	May use Weapons - Assault/Battle Rifle in place of Spotting when looking through your 
+12:	May use Weapons - Assault/Battle Rifle (PER) in place of Spotting when looking through your 
 	rifle's scope (warning, takes longer than wider field-of-view optics).
 24:	Halve the jam chance (applies after additive modifiers, round down, may be zero) of your 
 	assault/battle rifle for the first 3 rounds of its use per combat, once per short rest 
@@ -688,13 +688,17 @@ have no prerequisites.
 
 == Long Rifle Expertise ==
 
-0:	-5m to minimum range, +10% meters to R2 & R3		
-12:	-10% reload miss chance			
-24:	+10% to perception checks to spot enemies beyond your long rifle's R2 range			
-36:	-0.5 miss chance @ all ranges			
-48:	Gain feat "Beware the Wrath of a Patient Man": shots fired as a held reaction have a -1 miss chance.			
-60:	+10% Base damage; Once per turn may change aim between targets within 30 degrees 
-	as a free action by passing a DC 75 dexterity check
+0:	+10% to range R3.
+12:	May use Weapons - Long Rifle (STR) in place of Athletics in order to get to hard-to-reach
+	places, like towers or treetops, that can serve as sniper nests.
+24:	While prone, benefiting from at least light cover, and able to see at least one enemy, 
+	gain an additional +1 cover bonus.
+36:	Gain a stacking +0.5 Accuracy each time you consecutively spend an action shooting a 
+	single target without losing line of sight to it.
+48:	Halve any minimum range associated with your long rifle and attachments, to a max reduction 
+	of 5m.
+60:	Increase by 50% any numerical benefits of specialty ammunition you fire (does not affect 
+	Marksman Tech Rounds feats).
 	
 == Heavy Weapon Expertise ==
 


### PR DESCRIPTION
Some clarity updates/suggestions in previous skill substitutions.

Long Rifles, by their nature, live at the longest ranges and are at distinct disadvantages at any other due to their highly specialized designs. They also tend to be slower-firing and highly armor piercing, indicating a single-target focus.
0: Shoot even farther. It's what makes these guns special.
12: Another option is to replace Stealth checks to remain unobserved while motionless, but I went with Athl instead because I wanted more diversity in skill replacements and it's not necessarily the case that all snipers want to be stealthy. I figured it was sane that special sniper training includes getting to good vantage points.
24: Sneakerly and well-trained in the art of not getting shot back at.
36: Hint, hint, hint. Single target damage. Also encourages a good vantage point and somewhat alleviates range-based acc penalties.
48: Biggest weakness of long rifles is when someone walks right up to you. This doesn't actually make that a remotely favorable situation, but it does make it significantly less bad.
60: Inspired by Tech Rounds but balanced without them to try to avoid this being a mandatory feat for marksmen. Snipers should value having the right tool for the right job, especially as they should have to most time to swap tools of any class.