### PR TITLE
Added Melee Expertise and Improvisational Brawler

### DIFF
--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -246,6 +246,13 @@ Prerequisites:
 ranged weapons. In taking this feat you sacrifice the ability to use PER on 
 rolls dealing with using a weapon.
 
+== Improvisational Brawler ==
+Prerequisites:
+*  Melee Expertise
+
+	The benefits of the Melee Expertise feat now also apply to Improvised Melee 
+Weapons.
+
 == Improvise Weapon ==
 Prerequisites:
 
@@ -838,7 +845,25 @@ other weapons or class abilities. Does apply to Engineer mortars.
 	also set R2 equal to the new R1.
 60:	+10% Base damage. Other characters make Shock, Reflex, and Will saves associated 
 	with your explosives with Disadvantage.
-		
+
+== Melee Expertise ==
+
+	Applies to Melee Weapons that the user has Proficiency with and Unarmed Strike. 
+Does not apply to Improvised weapons. Reminder: these bonuses are only in effect while 
+you are wielding an appropriate weapon.
+
+0:	+1 Move Speed while using the Charge action with intent to engage an enemy in 
+	Melee Combat.
+12:	May use Weapons - Melee (Int) in place of Medicine on skill checks related to 
+	triaging and healing wounds inflicted by melee weapons, nonexplosive throwing 
+	weapons, or environmental damage that approximates a melee strike.
+24:	When defending against a disarm attempt, roll maneuver checks with Advantage.
+36:	+1 Accuracy when engaging a target wielding a melee weapon (unarmed counts).
+48:	+1 Guard when engaging a target wielding a melee weapon (unarmed counts).
+60:	+10% Base damage. Gain +0.5 Critical Hit range whenever you hit a target but
+	do not score a Critical Hit. This bonus resets if you score a Critical Hit, 
+	attack a different target, are stunned, or leave Melee Combat with that target.
+
 ==============================
 Active Feats
 ==============================

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -709,7 +709,8 @@ them all. The feats are formatted as a list of "X: Benefit", where X is the numb
 points required in the corresponding Weapon skill to gain the benefit.
 	
 	Weapon Expertise feats require proficiency with the weapon type, but otherwise 
-have no prerequisites.
+have no prerequisites. Note that as all characters are proficient with Unarmed Strike, 
+Melee Expertise effectively has no prerequisite.
 
 == Pistol Expertise ==	
 
@@ -854,15 +855,22 @@ you are wielding an appropriate weapon.
 
 0:	+1 Move Speed while using the Charge action with intent to engage an enemy in 
 	Melee Combat.
-12:	May use Weapons - Melee (Int) in place of Medicine on skill checks related to 
-	triaging and healing wounds inflicted by melee weapons, nonexplosive throwing 
-	weapons, or environmental damage that approximates a melee strike.
-24:	When defending against a disarm attempt, roll maneuver checks with Advantage.
+12:	May use Weapons - Melee (Str/Dex) in place of Acrobatics or Athletics on 
+	maneuver checks to avoid, gain control of, or escape a Grapple; defend against 
+	Disarm attempts; or defend against Trip attempts.
+24:	While wielding a Light or One-handed non-Hybrid weapon, whenever an enemy attacks 
+	you in Melee Combat and ties your Guard, you may make a melee attack against that 
+	enemy as a Reaction. 
+	While wielding a Hybrid or Two-handed weapon, you may choose to gain +2 to melee 
+	Accuracy checks for one round, but if you do then until the start of your next 
+	turn you take -2 to Guard checks.
+	If dual-wielding a Hybrid and Light or One-handed weapon, you may only use one 
+	of these effects per round, but may choose which.
 36:	+1 Accuracy when engaging a target wielding a melee weapon (unarmed counts).
 48:	+1 Guard when engaging a target wielding a melee weapon (unarmed counts).
-60:	+10% Base damage. Gain +0.5 Critical Hit range whenever you hit a target but
+60:	+10% Base damage. Gain +0.5 Critical Hit range whenever you hit an enemy but
 	do not score a Critical Hit. This bonus resets if you score a Critical Hit, 
-	attack a different target, are stunned, or leave Melee Combat with that target.
+	are stunned, or spend 1 round out of Melee Combat.
 
 ==============================
 Active Feats


### PR DESCRIPTION
Let's see about sneaking this in before expertise goes to dev.

> By default Melee expertise does not apply to improvised weapons, for flavor reasons. So I added 
> another feat to address that.

> Melee weapons are somewhat different from guns, and it is harder to follow the expertise design 
> guidelines here. I decided to focus on melee vs melee combat since the challenge of melee vs guns is 
> all about getting into range (only the 0 bonus really helps) and not remotely in anything you do to the 
> poor sniper after you're already in his/her face.
> 0:  First range buff replaced with a close equivalency in move speed. Guardrailed to prevent exploits 
> with switching to melee, moving, then back to a firearm.
> 12: Skill substitution is Medicine for healing wounds caused by melee/thrown weapons and similar 
> effects, reflecting that swordsmen know a lot more about slashing wounds than gunners.
> 24: Disarm resistance is vital to the successful melee combatant. Don't. let. go. of. the. sword.
> 36: Conditional accuracy slot reflects the advantage of training in melee combat
> 48: Second range modifier replaced with conditional Guard increase to complement the 36 slot. Guard 
> comes after Accuracy because defending is harder than attacking.
> 60: Capstone grants a stacking crit chance bonus in a way that emphasizes 'studying the opponent' 
> and 'looking for openings' tenets of melee combat. This needs to be watched to make sure it doesn't 
> enable a horribly broken crit build, but I tried to make it as safe as possible by requiring the ramping-
> up time.

> Once I look into throwing/bow expertise, this unboarded project should be concluded.