### PR TITLE
Turtlelord26 melee weapon damage patch

### DIFF
--- a/01_02_Combat_Rules.txt
+++ b/01_02_Combat_Rules.txt
@@ -293,7 +293,7 @@ stated.
 	Melee weapons come in one of four size categories. The first 
 three are Light, One-handed, and Two-handed. Characters start 
 with proficiency with some number of these based on their class. The 
-fifth category is Exotic. Acquiring proficiency with Exotic weapons does 
+fourth category is Exotic. Acquiring proficiency with Exotic weapons does 
 not grant access to all Exotic weapons, but rather to a particular type, 
 such as whips. Exotic proficiencies may rarely be granted by Backgrounds, 
 and are more commonly acquired by feats.

--- a/Items/04_01_Melee_&_Thrown_Weapons.txt
+++ b/Items/04_01_Melee_&_Thrown_Weapons.txt
@@ -21,16 +21,18 @@ MELEE WEAPONS
 
 ===== LEVEL 1 REQUIREMENT WEAPONS =====
 
-== Eliazar Plasma Torch $240 ==
+== Eliazar General-Purpose Welding Torch $170 ==
 
-Damage: 30 + 2x Plasma Burn
+Damage: 30 Fire + 2x Burn
 Size: Light
 Range: Adjacent (1m)
 Accuracy Modifier: +1
 STR Requirement:   3
 
-	Plasma. Can quickly repair vehicles with welding materials, seal/cut through 
-moderate doors, and make temporary cover. -40% stealth for being quiet on stealth attacks.
+	A vital tool for structural repairs - good for sealing or cutting  
+metal surfaces or slagging mechanisms like locks. Takes about 1 hour to 
+cut a median person-sized opening through half-inch steel plate. -40 on 
+Stealth rolls while using.
 
 == Gurber G1 Combat Knife $315 ==
 
@@ -49,6 +51,19 @@ Accuracy Modifier: +2
 DEX Requirement: 4
 
 ===== LEVEL 5 REQUIREMENT WEAPONS =====
+
+== Eliazar Plasma Torch $240 ==
+
+Damage: 30 Plasma + 2x Plasma Burn
+Size: Light
+Range: Adjacent (1m)
+Accuracy Modifier: +1
+STR Requirement:   3
+
+	A vital tool for structural repairs - good for sealing or cutting  
+metal surfaces or slagging mechanisms like locks. Takes about 40 minutes to 
+cut a median person-sized opening through half-inch steel plate. -40 on 
+Stealth rolls while using.
 
 == Guri Grabber Knife $470 ==
 

--- a/Items/04_01_Melee_&_Thrown_Weapons.txt
+++ b/Items/04_01_Melee_&_Thrown_Weapons.txt
@@ -49,7 +49,7 @@ DEX Requirement: 3
 
 Damage: 54 Ballistic + 2*STR mod + 1*DEX mod + 1xBleed
 Size: One-handed
-Range: 2m
+Range: Adjacent (1m)
 Accuracy Modifier: +2
 DEX Requirement: 4
 
@@ -118,7 +118,7 @@ materials. -50 on stealth checks while using.
 
 Damage: 56 Ballistic + 2*STR + 1*DEX + 1xBleed
 Size: One-handed
-Range: 2m
+Range: Adjacent (1m)
 Accuracy Modifier: +2
 DEX Requirement: 6
 
@@ -130,7 +130,7 @@ DEX Requirement: 6
 
 Damage: 32 Ballistic + 6*STR mod
 Size: Two-handed
-Range: 2m
+Range: Adjacent (1m)
 Accuracy Modifier: +0
 STR Requirement: 6
 
@@ -155,7 +155,7 @@ Guard modifier of 0.
 
 Damage: 56 Ballistic + 2*STR mod + DEX mod + 2xBleed
 Size: One-handed - Hybrid
-Range: 2m
+Range: Adjacent (1m)
 Accuracy Modifier: +2
 DEX Requirement: 6
 
@@ -165,7 +165,7 @@ DEX Requirement: 6
 
 Damage: 56 Plasma + 2*STR mod + DEX mod + 3xPlasma Burn
 Size: One-handed
-Range: 2m
+Range: Adjacent (1m)
 Accuracy Modifier: +2
 DEX Requirement: 4
 

--- a/Items/04_01_Melee_&_Thrown_Weapons.txt
+++ b/Items/04_01_Melee_&_Thrown_Weapons.txt
@@ -34,7 +34,7 @@ STR Requirement:   3
 
 	A vital tool for structural repairs - good for sealing or cutting  
 metal surfaces or slagging mechanisms like locks. Takes about 1 hour to 
-cut a median person-sized opening through half-inch steel plate. -40 on 
+cut an average person-sized opening through half-inch steel plate. -40 on 
 Stealth rolls while using. This weapon has an APL of 10.
 
 == Gurber G1 Combat Knife $315 ==
@@ -65,7 +65,7 @@ STR Requirement:   3
 
 	A vital tool for structural repairs - good for sealing or cutting  
 metal surfaces or slagging mechanisms like locks. Takes about 40 minutes to 
-cut a median person-sized opening through half-inch steel plate. -40 on 
+cut an average person-sized opening through half-inch steel plate. -40 on 
 Stealth rolls while using. This weapon has an APL of 10.
 
 == Guri Grabber Knife $470 ==
@@ -186,6 +186,7 @@ THROWN WEAPONS
 Damage: 34 Ballistic + 2*DEX mod + 1xBleed
 Size: Light
 DEX Requirement: 5
+Armor Piercing Level: 2
 
 	Ranged Miss Chance
 
@@ -202,6 +203,7 @@ Can carry 2 per Secondary Ammo Slot.
 Damage: 44 Ballistic + STR mod + DEX mod + 1xBleed
 Size: Light
 STR Requirement: 5
+Armor Piercing Level: 3
 
 	Ranged Miss Chance
 
@@ -218,6 +220,7 @@ Can carry 1 per Secondary Ammo Slot.
 Damage: 34 Ballistic + 2*DEX mod + 1xBleed
 Size: Light
 DEX Requirement: 6
+Armor Piercing Level: 4
 
 	Ranged Miss Chance
 
@@ -233,7 +236,7 @@ checks to hide the attack.
 Damage: 34 Plasma + 2*DEX mod + 3xPlasma Burn
 Size: Light
 DEX Requirement: 6
-AP Level: 5
+Armor Piercing Level: 5
 
 	Ranged Miss Chance
 

--- a/Items/04_01_Melee_&_Thrown_Weapons.txt
+++ b/Items/04_01_Melee_&_Thrown_Weapons.txt
@@ -11,9 +11,12 @@ UNARMED
 
 == Unarmed Strike ==
 
-Damage: 20 + STR mod + DEX mod, minimum 10
+Damage: 20 Ballistic + STR mod + DEX mod, minimum 10
 Range: Adjacent (1m)
 Accuracy Modifier: 0
+
+	Some species may have anatomies that allow for exotic damage types, 
+like Electric or Internal, on their Unarmed Strikes. DM discretion applies.
 
 ==============================
 MELEE WEAPONS
@@ -32,11 +35,11 @@ STR Requirement:   3
 	A vital tool for structural repairs - good for sealing or cutting  
 metal surfaces or slagging mechanisms like locks. Takes about 1 hour to 
 cut a median person-sized opening through half-inch steel plate. -40 on 
-Stealth rolls while using.
+Stealth rolls while using. This weapon has an APL of 10.
 
 == Gurber G1 Combat Knife $315 ==
 
-Damage: 40 + STR + 2*DEX + 1xBleed
+Damage: 34 Ballistic + 2*DEX mod + 1xBleed
 Size: Light
 Range: Adjacent (1m)
 Accuracy Modifier: +1
@@ -44,7 +47,7 @@ DEX Requirement: 3
 
 == Gurber GS101 Combat Sword $680 ==
 
-Damage: 50 + 2*STR + 2*DEX + 1xBleed
+Damage: 54 Ballistic + 2*STR mod + 1*DEX mod + 1xBleed
 Size: One-handed
 Range: 2m
 Accuracy Modifier: +2
@@ -63,36 +66,36 @@ STR Requirement:   3
 	A vital tool for structural repairs - good for sealing or cutting  
 metal surfaces or slagging mechanisms like locks. Takes about 40 minutes to 
 cut a median person-sized opening through half-inch steel plate. -40 on 
-Stealth rolls while using.
+Stealth rolls while using. This weapon has an APL of 10.
 
 == Guri Grabber Knife $470 ==
 
-Damage: 30 + STR + 2*DEX + 1xBleed
+Damage: 24 Ballistic + 2*DEX mod + 1xBleed
 Size: Light
 Range: Adjacent (1m)
 Accuracy Modifier: +1
 DEX Requirement: 5
 
-	You can grapple after any successful basic melee attack. +10% Skill on 
-grappling checks. Whenever you roll a successful grappling check, you may deal 
-[3*STR or 3*DEX] damage to your opponent.
+	Once per Ronud on your turn, you can attempt to grapple as a Free 
+Action after a successful basic melee attack. May use the Strike grappling 
+action as long as you are in control, without having to Pin the target first.
 
 == Guri Carbon Whip $560 ==
 
-Damage: 30 + 3*STR + 2*DEX
+Damage: 50 Ballistic + 2*DEX mod
 Size: Exotic - One-handed
 Range: 3m
 Accuracy Modifier: +1
 DEX Requirement: 6
 
-	Can grapple limbs from range (DEX based grapple) and force movement 
+	Can grapple limbs from range (Acrobatics based grapple) and force movement 
 (1m for every 5 [DEX or STR]). Can make Disarm attempts at range. Grapple, 
 Shove, and Disarm attempts with the whip costs Actions as normal. This weapon
 has a Guard modifier of 0.
 
 == SPECO SP10 VAE Combat Knife $640 ==
 
-Damage: 45 + STR + 2*DEX + 1xBleed
+Damage: 34 Ballistic + 2*DEX mod + 1xBleed
 Size: Light
 Range:  Adjacent (1m)
 Accuracy Modifier: +1
@@ -102,19 +105,18 @@ DEX Requirement: 4
 
 == SPECO SPC50 VAE Circular Saw $695 ==
 
-Damage: 55 + STR + 1xBleed
+Damage: 55 Ballistic + 1xBleed
 Size: Two-handed
 Range: Adjacent (1m)
 Accuracy Modifier: +1
 STR Requirement: 4
 
 	Voltage Aligned Edge; ignores standard armor; can easily cut through most 
-materials. -50 on stealth rolls for being quiet during stealth attacks with 
-this weapon.
+materials. -50 on stealth checks while using.
 
 == SPECO SP30 VAE Combat Sword $1245 ==
 
-Damage: 55 + 2*STR + 2*DEX + 1xBleed
+Damage: 56 Ballistic + 2*STR + 1*DEX + 1xBleed
 Size: One-handed
 Range: 2m
 Accuracy Modifier: +2
@@ -126,7 +128,7 @@ DEX Requirement: 6
 
 == Eliazar E500 Assisted-Sledgehammer $811 ==
 
-Damage: 50 + 6*STR
+Damage: 32 Ballistic + 6*STR mod
 Size: Two-handed
 Range: 2m
 Accuracy Modifier: +0
@@ -138,7 +140,7 @@ on stealth attacks. Reduces the DC to break down a door by 30 per hit.
 
 == Eliazar E5500 Power Fist $880 ==
 
-Damage: 50 + 5*STR
+Damage: 10 Ballistic + 5*STR mod
 Size: Light
 Range: Adjacent (1m)
 Accuracy Modifier: +1
@@ -151,7 +153,7 @@ Guard modifier of 0.
 
 == Muzashi VAE Katana $1354 ==
 
-Damage: 60 + STR + 3*DEX + 2xBleed
+Damage: 56 Ballistic + 2*STR mod + DEX mod + 2xBleed
 Size: One-handed - Hybrid
 Range: 2m
 Accuracy Modifier: +2
@@ -161,15 +163,15 @@ DEX Requirement: 6
 
 == Eliazar Plasma Sword $987 ==
 
-Damage: 50 + STR + 2*DEX + 3xPlasma Burn
+Damage: 56 Plasma + 2*STR mod + DEX mod + 3xPlasma Burn
 Size: One-handed
 Range: 2m
 Accuracy Modifier: +2
 DEX Requirement: 4
 
 	Plasma effect reduces armor by 1 level as usual, but this effect applies 
-during the sword hit (instead of after). If the target has a standard 
-(non-Nanite) shield, all plasma burn is canceled, the shield takes 30 damage and 
+during the sword hit (instead of after). If the target has a standard shield, 
+all plasma burn is canceled, the shield takes 30 damage and 
 the plasma sword passes through the shield.
 
 
@@ -181,66 +183,65 @@ THROWN WEAPONS
 
 == Gurber Throwing Knife $80 ==
 
-Damage: 15 + STR + DEX + 1xBleed
+Damage: 34 Ballistic + 2*DEX mod + 1xBleed
 Size: Light
 DEX Requirement: 5
-AP Level: 2
 
 	Ranged Miss Chance
 
-* 5 out to [DEX or STR/2] meters
-* 6 out to 5 + [DEX or STR/2] meters
+* 5 out to 7 meters
+* 6 out to 15 meters
 
-	For melee, 15+STR+2*DEX+1xBleed, +1 melee accuracy. 2 per Secondary Ammo Slot.
+	May be used for melee strikes with a -1 Accuracy penalty. 
+Can carry 2 per Secondary Ammo Slot.
 
 ===== LEVEL 5 REQUIREMENT WEAPONS =====
 
 == EAL Tactical Throwing Axe $160 ==
 
-Damage: 25 + 3*STR + DEX + 1xBleed
+Damage: 44 Ballistic + STR mod + DEX mod + 1xBleed
 Size: Light
 STR Requirement: 5
-AP Level: 3
 
 	Ranged Miss Chance
 
-* 5 out to STR + DEX/2 - 1 meters
-* 6 out to 5 + STR + DEX/2 meters
+* 5 out to 10 meters
+* 6 out to 15 meters
 
-	For melee, 40 + 2 * STR + DEX + 1 x Bleed, +1 melee accuracy. 1 per 
-Secondary Ammo Slot.
+	May be used for melee strikes with a -1 Accuracy penalty. 
+Can carry 1 per Secondary Ammo Slot.
 
 ===== LEVEL 10 REQUIREMENT WEAPONS =====
 
 == Carbide Kunai $120 ==
 
-Damage: 25 + STR + DEX + 1xBleed
+Damage: 34 Ballistic + 2*DEX mod + 1xBleed
 Size: Light
 DEX Requirement: 6
-AP Level: 4
 
 	Ranged Miss Chance
 
-*  5 out to [DEX or STR/2] meters
-*  6 out to 5 + [DEX or STR/2] meters
+*  5 out to 8 meters
+*  6 out to 15 meters
 
-	For melee, 20+STR+2*DEX+1xBleed, +1 melee accuracy. 3 per Secondary Ammo Slot.
-When thrown, +30% to stealth rolls to hide the attack.
+	May be used for melee strikes with a -1 Accuracy penalty. 
+Can carry 3 per Secondary Ammo Slot. When thrown, +30 to stealth 
+checks to hide the attack.
 
 == Plasma Catalyst Kunai $160 ==
 
-Damage: 10 + STR + DEX + 3xPlasma Burn
+Damage: 34 Plasma + 2*DEX mod + 3xPlasma Burn
 Size: Light
 DEX Requirement: 6
 AP Level: 5
 
 	Ranged Miss Chance
 
-* 5 out to [DEX or STR/2] meters
-* 6 out to 5 + [DEX or STR/2] meters
+* 5 out to 8 meters
+* 6 out to 15 meters
 
-	For melee, 15+STR+2*DEX+1xPlasma Burn, +1 melee accuracy. 3 per Secondary 
-Ammo Slot.
+	May be used for melee strikes with a -1 Accuracy penalty. 
+Can carry 3 per Secondary Ammo Slot.
 
 ==============================
 GRENADES

--- a/Items/04_01_Melee_&_Thrown_Weapons.txt
+++ b/Items/04_01_Melee_&_Thrown_Weapons.txt
@@ -11,7 +11,7 @@ UNARMED
 
 == Unarmed Strike ==
 
-Damage: 20 Ballistic + STR mod + DEX mod, minimum 10
+Damage: 20 + STR mod + DEX mod Ballistic, minimum 10
 Range: Adjacent (1m)
 Accuracy Modifier: 0
 
@@ -39,7 +39,7 @@ Stealth rolls while using. This weapon has an APL of 10.
 
 == Gurber G1 Combat Knife $315 ==
 
-Damage: 34 Ballistic + 2*DEX mod + 1xBleed
+Damage: 34 + 2*DEX mod Ballistic + 1xBleed
 Size: Light
 Range: Adjacent (1m)
 Accuracy Modifier: +1
@@ -47,7 +47,7 @@ DEX Requirement: 3
 
 == Gurber GS101 Combat Sword $680 ==
 
-Damage: 54 Ballistic + 2*STR mod + 1*DEX mod + 1xBleed
+Damage: 54 + 2*STR mod + 1*DEX mod Ballistic + 1xBleed
 Size: One-handed
 Range: Adjacent (1m)
 Accuracy Modifier: +2
@@ -70,7 +70,7 @@ Stealth rolls while using. This weapon has an APL of 10.
 
 == Guri Grabber Knife $470 ==
 
-Damage: 24 Ballistic + 2*DEX mod + 1xBleed
+Damage: 24 + 2*DEX mod Ballistic + 1xBleed
 Size: Light
 Range: Adjacent (1m)
 Accuracy Modifier: +1
@@ -82,7 +82,7 @@ action as long as you are in control, without having to Pin the target first.
 
 == Guri Carbon Whip $560 ==
 
-Damage: 50 Ballistic + 2*DEX mod
+Damage: 50 + 2*DEX mod Ballistic
 Size: Exotic - One-handed
 Range: 3m
 Accuracy Modifier: +1
@@ -95,7 +95,7 @@ has a Guard modifier of 0.
 
 == SPECO SP10 VAE Combat Knife $640 ==
 
-Damage: 34 Ballistic + 2*DEX mod + 1xBleed
+Damage: 34 + 2*DEX mod Ballistic + 1xBleed
 Size: Light
 Range:  Adjacent (1m)
 Accuracy Modifier: +1
@@ -116,7 +116,7 @@ materials. -50 on stealth checks while using.
 
 == SPECO SP30 VAE Combat Sword $1245 ==
 
-Damage: 56 Ballistic + 2*STR + 1*DEX + 1xBleed
+Damage: 56 + 2*STR + 1*DEX Ballistic + 1xBleed
 Size: One-handed
 Range: Adjacent (1m)
 Accuracy Modifier: +2
@@ -128,7 +128,7 @@ DEX Requirement: 6
 
 == Eliazar E500 Assisted-Sledgehammer $811 ==
 
-Damage: 32 Ballistic + 6*STR mod
+Damage: 32 + 6*STR mod Ballistic, minimum 20
 Size: Two-handed
 Range: Adjacent (1m)
 Accuracy Modifier: +0
@@ -140,7 +140,7 @@ on stealth attacks. Reduces the DC to break down a door by 30 per hit.
 
 == Eliazar E5500 Power Fist $880 ==
 
-Damage: 10 Ballistic + 5*STR mod
+Damage: 10 + 5*STR mod Ballistic, minimum 20
 Size: Light
 Range: Adjacent (1m)
 Accuracy Modifier: +1
@@ -153,7 +153,7 @@ Guard modifier of 0.
 
 == Muzashi VAE Katana $1354 ==
 
-Damage: 56 Ballistic + 2*STR mod + DEX mod + 2xBleed
+Damage: 56 + 2*STR mod + DEX mod Ballistic + 2xBleed
 Size: One-handed - Hybrid
 Range: Adjacent (1m)
 Accuracy Modifier: +2
@@ -163,7 +163,7 @@ DEX Requirement: 6
 
 == Eliazar Plasma Sword $987 ==
 
-Damage: 56 Plasma + 2*STR mod + DEX mod + 3xPlasma Burn
+Damage: 56 + 2*STR mod + DEX mod Plasma + 2xPlasma Burn
 Size: One-handed
 Range: Adjacent (1m)
 Accuracy Modifier: +2
@@ -183,7 +183,7 @@ THROWN WEAPONS
 
 == Gurber Throwing Knife $80 ==
 
-Damage: 34 Ballistic + 2*DEX mod + 1xBleed
+Damage: 34 + 2*DEX mod Ballistic + 1xBleed
 Size: Light
 DEX Requirement: 5
 Armor Piercing Level: 2
@@ -200,7 +200,7 @@ Can carry 2 per Secondary Ammo Slot.
 
 == EAL Tactical Throwing Axe $160 ==
 
-Damage: 44 Ballistic + STR mod + DEX mod + 1xBleed
+Damage: 44 + STR mod + DEX mod Ballistic + 1xBleed
 Size: Light
 STR Requirement: 5
 Armor Piercing Level: 3
@@ -217,7 +217,7 @@ Can carry 1 per Secondary Ammo Slot.
 
 == Carbide Kunai $120 ==
 
-Damage: 34 Ballistic + 2*DEX mod + 1xBleed
+Damage: 34 + 2*DEX mod Ballistic + 1xBleed
 Size: Light
 DEX Requirement: 6
 Armor Piercing Level: 4
@@ -233,7 +233,7 @@ checks to hide the attack.
 
 == Plasma Catalyst Kunai $160 ==
 
-Damage: 34 Plasma + 2*DEX mod + 3xPlasma Burn
+Damage: 34 + 2*DEX mod Plasma + 3xPlasma Burn
 Size: Light
 DEX Requirement: 6
 Armor Piercing Level: 5

--- a/Items/04_01_Melee_&_Thrown_Weapons.txt
+++ b/Items/04_01_Melee_&_Thrown_Weapons.txt
@@ -88,7 +88,7 @@ Range: 3m
 Accuracy Modifier: +1
 DEX Requirement: 6
 
-	Can grapple limbs from range (Acrobatics based grapple) and force movement 
+	Can grapple limbs from range (Acrobatics-based grapple) and force movement 
 (1m for every 5 [DEX or STR]). Can make Disarm attempts at range. Grapple, 
 Shove, and Disarm attempts with the whip costs Actions as normal. This weapon
 has a Guard modifier of 0.


### PR DESCRIPTION
#575, #577 

From 526a037 commit notes

> Design consistencies.
> 
> Daggers should do about 50 damage for someone with 7 Dex & Str (mods of 8), Swords 80.
> Nonexotic Light weapons have a maximum total attribute modifier of 2, One-handed 3. Two-handed 
> can go higher with Str mutipliers.
> * Tools like torches get no attribute bonuses.
> * Daggers receive 2x Dex but no Str, 
> * Swords and Axes get 2x Str and 1x Dex
> * Spears and hammers, for example, I would rate at 3x Str, no Dex
> 
> Throwing weapons set approx equivalent to their melee counterparts, dropping a level of STR mod if 
> applicable. I gave the Axes +10 damage compared to to the knives.
> 
> Specific Notes:
> The grabber knife lost 10 damage from the new baseline for its ability to start free grapples. I 
> reworked the rest to be more streamlines.
> The whip's target damage is 66.
> The Fist and sledge hammer kept their obnoxiously high Str multipliers, but had base damage reduced 
> to keep the ceiling reasonable.