### PR TITLE
Turtlelord26 Nanite Removal: Cloak Rules Update

### DIFF
--- a/01_07_Cloaking_Rules.txt
+++ b/01_07_Cloaking_Rules.txt
@@ -6,24 +6,21 @@ Cloaking
  
 ===== Cloaking Modules =====
 
-    Expend the cloaking module's "Nanite Activation Cost" to begin cloaking. At 
-the ending of every turn thereafter, you have to pay a "Nanite Upkeep" cost to 
-continue cloaking.
+	To activate a cloaking module, you must expend an amount of Energy, 
+from the cloak module's built-in power or an external battery, the cloaking 
+module's Energy Activation Cost. Whenever you end a turn cloaked, you must pay 
+the module's Energy Upkeep cost or the cloak immediately deactivates. If you 
+performed no Actions, the Upkeep cost is halved for that turn.
 
-    Wearers need only expend Nanites for the "Nanite Upkeep" cost at the end 
-of a turn that they perform actions. Cloaking requires concentration so when you 
-are doing nothing but watching, you may cloak for free.
-
-    You can remain cloaked for a number of turns equal to ["Cloak Turns" + your
-cloaking module's "Cloak Turn Bonus"] or when you run out of Nanites, whichever 
-occurs sooner (see table below for "Cloak Turns") . If your cloak time runs out, 
-you stop cloaking and have to wait a number of actions equal to your "Charge 
-Delay" (listed under the relevant cloaking module's description) before being 
-able to cloak again.
+	You may remain cloaked for a number of turns equal to your cloak module's 
+Overheat stat or when you run out of Energy, whichever occurs sooner. hen you 
+decloak, for whatever reason, you must wait a number of actions equal to the 
+module's "Charge Delay" (listed under the relevant cloaking module's description) 
+before being able to cloak again.
 
 ===== Cloaking Detection =====
 
-    If someone/something is looking for you, they must pass a (normally, 
+	If someone/something is looking for you, they must pass a (normally, 
 perception) check at 'Detect DC' difficulty, modified by your Stealth skill. 
 While moving, the Detect DC is reduced (listed as 'moving Detect DC' under the 
 relevant cloaking module's description). There is a tell-tale shimmer in the 
@@ -31,54 +28,52 @@ cloak, as the micro-foil has a hard time keeping up with moving environments.
 Once the wearer has settled down, the micro-foil is able to reproduce the 
 surrounding environment better and will stabilize.
 
-    When using a skill (accessing a terminal, fixing something, etc.) use your 
+	When using a skill (accessing a terminal, fixing something, etc.) use your 
 reduced, 'moving Detect DC' as you are diverting your attention. However, once 
 you have performed a combat action, the cloak fizzes out.
 
 ===== CLOAKING DURATIONS AND LEVELING BONUSES =====
 
-+-----------+-------------+-----------+-----------------+
-| Char lv   | Cloak Turns | Detect DCs| Shadow Assn turn|
-+-----------+-------------+-----------+-----------------+
-|     1*    |      3      |     -     |        +1       |
-+-----------+-------------+-----------+-----------------+
-|     2*    |      3      |     -     |        -        |
-+-----------+-------------+-----------+-----------------+
-|     3*    |      3      |     -     |        -        |
-+-----------+-------------+-----------+-----------------+
-|     4*    |      4      |     -     |        -        |
-+-----------+-------------+-----------+-----------------+
-|     5     |      4      |    +5%    |        -        |
-+-----------+-------------+-----------+-----------------+
-|     6     |      4      |     -     |        +2       |
-+-----------+-------------+-----------+-----------------+
-|     7     |      5      |     -     |        -        |
-+-----------+-------------+-----------+-----------------+
-|     8     |      5      |     -     |        -        |
-+-----------+-------------+-----------+-----------------+
-|     9     |      5      |     -     |        -        |
-+-----------+-------------+-----------+-----------------+
-|     10    |      6      |   +10%    |        -        |
-+-----------+-------------+-----------+-----------------+
-|     11    |      6      |     -     |        +3       |
-+-----------+-------------+-----------+-----------------+
-|     12    |      6      |     -     |        -        |
-+-----------+-------------+-----------+-----------------+
-|     13    |      7      |     -     |        -        |
-+-----------+-------------+-----------+-----------------+
-|     14    |      7      |     -     |        -        |
-+-----------+-------------+-----------+-----------------+
-|     15    |      7      |   +15%    |        -        |
-+-----------+-------------+-----------+-----------------+
-|     16    |      8      |     -     |        +4       |
-+-----------+-------------+-----------+-----------------+
-|     17    |      8      |     -     |        -        |
-+-----------+-------------+-----------+-----------------+
-|     18    |      9      |     -     |        -        |
-+-----------+-------------+-----------+-----------------+
-|     19    |      9      |     -     |        -        |
-+-----------+-------------+-----------+-----------------+
-|     20    |      10     |   +20%    |        +5       |
-+-----------+-------------+-----------+-----------------+
-The Table bonuses are not cumulative.
-*  For levels 1-4, you may only cloak once per encounter.
++-----------+-----------+-----------------+
+| Char lv   | Detect DCs| Shadow Assn turn|
++-----------+-----------+-----------------+
+|     1     |     -     |        +1       |
++-----------+-----------+-----------------+
+|     2     |     -     |        -        |
++-----------+-----------+-----------------+
+|     3     |     -     |        -        |
++-----------+-----------+-----------------+
+|     4     |     -     |        -        |
++-----------+-----------+-----------------+
+|     5     |    +5%    |        -        |
++-----------+-----------+-----------------+
+|     6     |     -     |        +2       |
++-----------+-----------+-----------------+
+|     7     |     -     |        -        |
++-----------+-----------+-----------------+
+|     8     |     -     |        -        |
++-----------+-----------+-----------------+
+|     9     |     -     |        -        |
++-----------+-----------+-----------------+
+|     10    |   +10%    |        -        |
++-----------+-----------+-----------------+
+|     11    |     -     |        +3       |
++-----------+-----------+-----------------+
+|     12    |     -     |        -        |
++-----------+-----------+-----------------+
+|     13    |     -     |        -        |
++-----------+-----------+-----------------+
+|     14    |     -     |        -        |
++-----------+-----------+-----------------+
+|     15    |   +15%    |        -        |
++-----------+-----------+-----------------+
+|     16    |     -     |        +4       |
++-----------+-----------+-----------------+
+|     17    |     -     |        -        |
++-----------+-----------+-----------------+
+|     18    |     -     |        -        |
++-----------+-----------+-----------------+
+|     19    |     -     |        -        |
++-----------+-----------+-----------------+
+|     20    |   +20%    |        +5       |
++-----------+-----------+-----------------+

--- a/Items/05_Armors.txt
+++ b/Items/05_Armors.txt
@@ -467,15 +467,15 @@ Stealth Skill Required:	10
 Prim Module Hard Pts: 	1
 Detect DC:		75
 Moving Detect DC:   	50
-Cloak Turn Bonus:	+0
-Charge Delay:    	3 Actions
+Overheat:		3 Rounds
+Charge Delay:    	Encounter
 Nanite Activation Cost:	7
 Nanite Upkeep:   	7
 
 Secondary Module Cost:	800
 Sec Module Hard Pts:	1
-Secondary Module Benefit: Provides +1 Cloak Turn
-Bonus, -1 Nanite Upkeep, per secondary module
+Secondary Module Benefit: Provides +1 Overheat,
+-1 Nanite Upkeep, per secondary module
 
 =====   LEVEL 5 REQUIREMENT   =====
 	
@@ -485,7 +485,7 @@ Stealth Skill Required:	10
 Prim Module Hard Pts: 	1
 Detect DC:		25
 Moving Detect DC:   	0
-Cloak Turn Bonus:	+Infinite
+Overheat:		None
 Charge Delay:    	0 Actions; Attempts to passively camouflage you, at all times, while active.
 Nanite Activation Cost:	7
 Nanite Upkeep:   	5
@@ -506,8 +506,8 @@ Stealth Skill Required:	15
 Prim Module Hard Pts: 	2
 Detect DC:		100
 Moving Detect DC:   	75
-Cloak Turn Bonus:	+0
-Charge Delay:    	3 Actions
+Overheat:		5 Rounds
+Charge Delay:    	2 Rounds
 Nanite Activation Cost:	13
 Nanite Upkeep:   	8
 
@@ -525,8 +525,8 @@ Stealth Skill Required:	25
 Prim Module Hard Pts: 	2
 Detect DC:		100
 Moving Detect DC:   	75
-Cloak Turn Bonus:	+4
-Charge Delay:    	3 Actions
+Overheat:		10 Rounds
+Charge Delay:    	1 Round
 Nanite Activation Cost:	35
 Nanite Upkeep:   	3
 


### PR DESCRIPTION
Nanites -> Energy in the Cloak Rules file. Also general wording improvement.

Removed Cloak Turns stat. Made new Overheat stat to cover that functionality - cloak duration is now based on your equipment instead of your level.
Clarified Charge Delay stat, massaged its numbers to make more sense with new Overheat.