### PR TITLE
De-duplicated and re-arranged basic rules

### DIFF
--- a/01_01_Basic_Rules.txt
+++ b/01_01_Basic_Rules.txt
@@ -1,12 +1,20 @@
 ==============================
+Basic Rules
+==============================
+	
+	Welcome to Compound X! The game of squad tactics, space exploration and 
+exciting role playing! On behalf of the develpment team, thanks for playing and
+have fun!
+
+==============================
 Premise
 ==============================
 
-	Welcome to Compound X! The specific time and place that your adventure takes
-place is up to your Game Master (often called a GM for short), but all of them
-take place far in the future where humans have left earth on their faster-than-light
-spaceships to explore dangerous new worlds fraught with friend and foe of all
-manner of robots and aliens! 
+	The specific time and place that your adventure takes place is up to your 
+Game Master (often called a GM for short), but all of them take place far in the 
+future where humans have left earth on their faster-than-light spaceships to 
+explore dangerous new worlds fraught with friend and foe of all manner of robots 
+and aliens! 
 
 	Will you be the dashing hero? Or perhaps the evil villain plotting galactic 
 domination? Or maybe a mercenary who's somewhere in between? The choice is
@@ -118,11 +126,21 @@ see the 00_New_Player_Walkthrough.txt document in CharacterCreation. Following
 its steps will give you a customized, relatively low-complexity character that 
 will help you learn to play the rest of Compound X.
 
-Base Stats:
+Primary Stats:
 	These decide what raw characteristics make up your character, and are 
 factored into most other decisions you make both in game and for the rest of 
 character creation. Choosing your stats is a very good way to start making a 
 character.
+
+Secondary Stats:
+	These stats are derived from your primary stats and determine things like
+how fast your character moves and how quickly they learn new skills. When making
+a new character, you'll calculate these after picking Primary Stats.
+
+Stat and Combat Modifiers:
+	These numbers are calculated from your stats, and are often added to dice
+rolls to show how your character's physical and mental abilities affect how they
+do at different tasks.
 
 Species/Race:
 	Is your character a robot? What about a human? Or maybe the catlike aliens 
@@ -164,81 +182,10 @@ from reloading really fast, to having more health to being able to do a fast
 combat roll under fire. Tackle these when your character advances to level 3.
 
 ==============================
-Base Stats
+Primary Stats and Secondary Stats
 ==============================
 
-	Each player has what are called Base Stats. An average person has a '5' for
-each stat, but an average player has a '6'. Base Stats are split into Primary
-and Secondary stats. Primary stats are determined by your Base Stat points.
-Secondary stats are derived from primary stats. The largest primary stat
-associated with a given secondary stat determines the secondary stat's value; 
-However, if you have a primary stat that is associated with more than one 
-secondary stat, you may have to choose which secondary stat to contribute to.
-These stats are as follows (secondary stat associations are indented):
-
-Strength:
-* Carry Ability
-* Movement Speed
-Perception:
-* None
-Fortitude:
-* Carry Ability
-Charisma:
-* Skill Point Gain
-Intelligence:
-* Skill Point Gain
-Dexterity:
-* Movement Speed
-Luck:
-* None
-
-Secondary Stat Assignment Examples: 
-	Charisma and Intelligence are associated with Skill Point Gain. If you have 
-5 Charisma and 6 Intelligence, you would have 6 Skill Point Gain.
-
-	Let's now assume you have 6 Strength, 3 Dexterity, and 4 Fortitude. You would 
-have 3 Movement Speed (from your Dexterity) and 4 Carry Ability (from your Fortitude). 
-Now, Strength is much higher than both of those, but Strength can't determine both 
-Movement Speed and Carry Ability so you have to decide whether you want:
-
-* 3 Movement Speed and 6 Carry Ability, or 
-* 6 Movement Speed and 4 Carry Ability 
-
-	Strength determining Movement Speed is likely to be the better choice, as 
-Carry Ability doesn't contribute as much to your character (see Secondary Stat 
-Details, below)and you have a total of 6 + 4 = 10 points in secondary stats 
-instead of 3 + 6 = 9. 
-
-	Usually you can tell a lot about a character just by their base stats. For 
-instance, a character with 9 strength and 3 intelligence is usually either a 
-brutish bully or a tough but lovable teddy bear of a person. Where a character 
-with 10 intelligence and 2 charisma is probably a brilliant nerd who might be 
-shy or just have a terrible stutter.
-
-	But your raw base stat is rarely used in calculations during the game. To
-get the math to work out better, we usually us what is called a 'Stat Bonus'.
-Stat bonuses are used very often. They are calculated by one of the two equivalent 
-equations below (use whichever looks easier to you):
-
-* Stat Bonus = (4 * Stat) - 20 
-* Stat Bonus = (Stat - 5) * 4
-
-	For instance, if you were trying to lift something heavy, your GM may tell 
-you to roll a 'Strength Check' and add your 'Strength Bonus'. To do this, you 
-would roll two 10-sided dice as explained in the Primary Game Mechanic above, 
-and add your Strength Bonus to that. Let's say that you rolled a 71, and your 
-Strength Base Stat is a very beefy 8. Then your Strength bonus would be:
-
-	(8 - 5) * 4 = 3 * 4 = 12
-
-	and the score of your roll would be 
-
-	71 + 12 = 83
-
-	That's a really high roll! But that may or may not be enough to lift the 
-object depending on how heavy it is!
-
-===== Primary Stat Details =====	
+===== Primary Stats =====
 
 Strength (STR):
 	How strong are you? This stat determines how big of a gun you can carry and
@@ -346,23 +293,76 @@ table, below.
 | 9-10  | Nothing bad happens... this time                                                      |
 +-------+---------------------------------------------------------------------------------------+
 
+===== Secondary Stats =====	
 
-===== Secondary Stat Details =====
+	Your Character's Secondary stats are each equal to one of your Primary 
+Stats, but no single Primary Stat can be used for two of your Secondary Stats.
 
 Movement Speed:
-	Your speed in meters, for every two actions. Use (Movement Speed)/2 for one 
-action (drop the remainder). For more information, see topic "Movement and 
-Sprinting", below.
+	Your Movement Speed is how fast your character can move every two Actions in
+combat, measured in meters. Use (Movement Speed)/2 for one Action and drop the 
+remainder. For more detail on movement in combat, see the "Movement and 
+Sprinting" topic in the Combat Rules. Your Movment Speed is either equal to your
+Strength or your Dexterity.
 
 Carry Ability:
-	Cancels out movement speed penalties. Carry Ability allows you to carry 
-heavier weapons or heavier armor without slowing you down. If you have 6 Carry 
-Ability and 6m of movement speed penalties, you end up with no movement speed 
-penalties.
+	Your Character's Carry Ability is how much heavy equipment they can lug
+around before it starts to slow them down. Each point in Carry Ability negates
+1 meter per Action of movement penalty from weapons, armor or other items. If 
+you have 6 Carry Ability and 6m of movement speed penalties, you end up with no 
+movement speed penalties and can move your full Movement Speed for every Two
+Actions. Your Carry Ability is either equal to your Strength or your Fortitude.
 
 Skill Point Gain:
-	Determines how many skill points you gain every level. Every time you level up, you 
-gain skill points equal to double your "Skill Point Gain".
+	Your Character's Skill Point Gain determines how many skill points you gain 
+every level. Every time you level up, you gain skill points equal to double your 
+"Skill Point Gain". Your Skill Point Gain should be equal to either your 
+Intelligence or your Charisma.
+
+== Secondary Stat Assignment Examples ==
+	Charisma and Intelligence are associated with Skill Point Gain. If you have 
+5 Charisma and 6 Intelligence, you would have 6 Skill Point Gain.
+
+	Let's now assume you have 6 Strength, 3 Dexterity, and 4 Fortitude. You would 
+have 3 Movement Speed (from your Dexterity) and 4 Carry Ability (from your Fortitude). 
+Now, Strength is much higher than both of those, but Strength can't determine both 
+Movement Speed and Carry Ability so you have to decide whether you want:
+
+* 3 Movement Speed and 6 Carry Ability, or 
+* 6 Movement Speed and 4 Carry Ability 
+
+===== Stat Modifiers =====
+
+	Usually you can tell a lot about a character just by their Primary Stats. 
+For instance, a character with 9 strength and 3 intelligence is usually either a 
+brutish bully or a tough but lovable teddy bear of a person. Where a character 
+with 10 intelligence and 2 charisma is probably a brilliant nerd who might be 
+shy or just have a terrible stutter.
+
+	But your raw base stat is rarely used in calculations during the game. To
+get the math to work out better, we usually use what is called a 'Stat Modifier'.
+Stat Modifiers are used very often. They are calculated by one of the two 
+equivalent equations below (use whichever looks easier to you):
+
+* Stat Modifier = (4 * Stat) - 20 
+* Stat Modifier = (Stat - 5) * 4
+
+	For instance, if you were trying to lift something heavy, your GM may tell 
+you to roll a 'Strength Check' and add your 'Strength Modifier'. To do this, you 
+would roll two 10-sided dice as explained in the Primary Game Mechanic above, 
+and add your Strength Modifier to that. Let's say that you rolled a 71, and your 
+Strength Primary Stat is a very beefy 8. Then your Strength Modifier would be:
+
+	(8 - 5) * 4 = 3 * 4 = 12
+
+	and the score of your roll would be 
+
+	71 + 12 = 83
+
+	That's a really high roll! But that may or may not be enough to lift the 
+object depending on how heavy it is.
+
+
 
 ===== Nanites =====
 
@@ -377,8 +377,9 @@ Some class feats and other abilities can increase the number of Nanites you can
 hold and use at a given time. Also, Unlike Health, Nanites regenerate during 
 combat at a rate of 3 Nanites per turn. 
 	
-
-===== Assigning Stats to a New Character =====
+==============================
+Creating a New Character
+==============================
 
 	When making a new character, you'll have to assign their Base stats.
 This will tell you a lot about your character. When assigning your stats,
@@ -391,7 +392,7 @@ level 15. After level 15, the limit for stat points is 20. The number of
 initial base stat points that you have to apply is listed with your Race or 
 Species. See chapter 1: Races if you haven't yet. 
 
-===== Assigning A Class to your Character =====
+===== Assigning a Class to your Character =====
 
 	Most Characters start at level 1 so the Player will choose a Class for that 
 Character at that time. A Character will only ever have one Class at a time, and
@@ -438,7 +439,7 @@ increase per level.
 Saving Throws
 ==============================
 
-	Saving throws are used in dire or critical situations to defend against very 
+	Saving Throws are used in dire or critical situations to defend against very 
 negative effects.
 
 - Will: defend against a mind affect (Ex: throw off hopelessness after crashing in an escape pod)
@@ -446,12 +447,77 @@ negative effects.
 - Reflex: quickly react to an event (Ex: dodge falling debris, fire at an enemy if they leap from one piece of cover to another)
 - Awareness: knowledge and understanding of surroundings (Ex: realizing someone has walked up behind you)
 
-The equations are as follows:
+The equations to calculate your bonuses to Saving Throws are as follows:
 
 - Will: 2*(Cha + Int - 6) Rational: Normally wisdom would be applied, so Will in Compound X is descried as your internal voice motivating you to endure a mental hardship.
 - Shock: 2*(Fort + Int - 6) Rational: You need to recognize that you are in shock, and resist its physical effects.
 - Reflex: 2*(Per + Dex - 6) Rational: In order to react quickly to an event you need to be able to see it coming.
 - Awareness: 2*(Per + Luc - 6) Rational: Line of sight and concentration are integral parts to being able to detect anomalies in the area.  
+
+==============================
+Feats
+==============================
+
+	As your character levels up and gets better at what they do, they develop
+certain talents and abilities that help them differentiate themselves from their
+peers. These special tallents and abilities are called "Feats". See the 
+"Leveling Up Rules" table to see how many feats you get at which levels. Unless 
+otherwise specified, you cannot take a feat more than once.
+
+	There are Five kinds of feats and we'll detail them below;
+
+* Passive Feats
+* Active Feats
+* Weapon Expertise Feats
+* Stat Feats
+* Class Feats
+
+Passive Feats:
+
+	When you take a feat, you may take a passive feat. Passive Feats are used 
+freely with no limit unless otherwise stated. They often give bonuses to skills
+or to rolls for certain actions.
+
+Active Feats:
+
+	When you take a feat, you may decide to take an Active Feat. An Active Feat
+gives your character the option of taking certain actions that they otherwise
+couldn't, usually in combat. Active feats cost a certain amount of Nanites to
+execute, and if your character doesn't have enough nanites, then they can't take
+that action until they get some more. 
+
+Weapon Expertise Feats:
+	
+	When you take a feat, you may decide to take a Weapon Expertise Feat. Weapon
+Expertise Feats are a special kind of passive feat, that get better as you 
+increase your skill with a particular kind of weapon group. 
+
+	These feats represent dedicated training with a particular class of weapon, 
+and offer bonuses based on the relevant Weapons skill (Weapon skills are listed 
+in "06_Skills.txt"). Each feat offers a set of bonuses related to using that type of 
+weapon (and only that type of weapon), and each bonus requires the character to have 
+a number of points in the relevant Weapon skill. A character with 0 points in 
+Weapons - Pistols would gain only one benefit, while 60 points would benefit from 
+them all. The feats are formatted as a list of "X: Benefit", where X is the number of 
+points required in the corresponding Weapon skill to gain the benefit.
+	
+	Weapon Expertise feats require proficiency with the weapon type, but otherwise 
+have no prerequisites. Note that as all characters are proficient with Unarmed 
+Strike, Melee Expertise effectively has no prerequisite.
+
+Primary Stat Feats:
+	
+	Stat Feats are special and cannot be taken when you get a feat like Active
+or Passive Feats. Instead, they are immediately unlocked when you fulfill their
+Luck or Charisma requirement. 
+
+Class Feats:
+
+	On certain levels, you will unlock a Class Feat instead of a Regular Feat.
+You cannot take a Class Feat when you get a regular Feat, nor can you forego 
+your Class Feat in favor of an Active or Passive feat. You can only unlock one
+Class Feat at a time. Class Feats are listed in the Classes document under the
+appropriate class. 
 
 ==============================
 Healing Injuries

--- a/01_01_Basic_Rules.txt
+++ b/01_01_Basic_Rules.txt
@@ -10,11 +10,11 @@ have fun!
 Premise
 ==============================
 
-	The specific time and place that your adventure takes place is up to your 
-Game Master (often called a GM for short), but all of them take place far in the 
-future where humans have left earth on their faster-than-light spaceships to 
-explore dangerous new worlds fraught with friend and foe of all manner of robots 
-and aliens! 
+	The specific time and place of your adventures is up to your Game Master 
+(often called a GM for short), but all of them take place far in the future 
+where humans have left earth on their faster-than-light spaceships to explore 
+dangerous new worlds fraught with friends and foes and all manner of robots and 
+aliens! 
 
 	Will you be the dashing hero? Or perhaps the evil villain plotting galactic 
 domination? Or maybe a mercenary who's somewhere in between? The choice is
@@ -139,8 +139,8 @@ a new character, you'll calculate these after picking Primary Stats.
 
 Stat and Combat Modifiers:
 	These numbers are calculated from your stats, and are often added to dice
-rolls to show how your character's physical and mental abilities affect how they
-do at different tasks.
+rolls to show how your character's physical and mental abilities affect how well 
+they perform different tasks.
 
 Species/Race:
 	Is your character a robot? What about a human? Or maybe the catlike aliens 
@@ -323,10 +323,11 @@ Intelligence or your Charisma.
 	Charisma and Intelligence are associated with Skill Point Gain. If you have 
 5 Charisma and 6 Intelligence, you would have 6 Skill Point Gain.
 
-	Let's now assume you have 6 Strength, 3 Dexterity, and 4 Fortitude. You would 
-have 3 Movement Speed (from your Dexterity) and 4 Carry Ability (from your Fortitude). 
-Now, Strength is much higher than both of those, but Strength can't determine both 
-Movement Speed and Carry Ability so you have to decide whether you want:
+	Let's now assume you have 6 Strength, 3 Dexterity, and 4 Fortitude. You 
+could have 3 Movement Speed (from your Dexterity) and 4 Carry Ability (from your 
+Fortitude). Now, Strength is much higher than both of those, but Strength can't 
+determine both Movement Speed and Carry Ability so you have to decide whether 
+you want:
 
 * 3 Movement Speed and 6 Carry Ability, or 
 * 6 Movement Speed and 4 Carry Ability 
@@ -339,7 +340,7 @@ brutish bully or a tough but lovable teddy bear of a person. Where a character
 with 10 intelligence and 2 charisma is probably a brilliant nerd who might be 
 shy or just have a terrible stutter.
 
-	But your raw base stat is rarely used in calculations during the game. To
+	But your raw Primary Stat is rarely used in calculations during the game. To
 get the math to work out better, we usually use what is called a 'Stat Modifier'.
 Stat Modifiers are used very often. They are calculated by one of the two 
 equivalent equations below (use whichever looks easier to you):
@@ -381,13 +382,13 @@ combat at a rate of 3 Nanites per turn.
 Creating a New Character
 ==============================
 
-	When making a new character, you'll have to assign their Base stats.
+	When making a new character, you'll have to assign their Primary Stats.
 This will tell you a lot about your character. When assigning your stats,
 no stat can be higher than a 9 before applying racial/species bonuses and
 no stat can be lower than a 1 after applying racial/species bonuses. 
 
-	Additionally, even after race/species bonuses, feats, equipment, and base stat 
-bonuses from leveling, no stat can ever be over 15 until your character is 
+	Additionally, even after race/species bonuses, feats, equipment, and Primary
+Stat bonuses from leveling, no stat can ever be over 15 until your character is 
 level 15. After level 15, the limit for stat points is 20. The number of 
 initial base stat points that you have to apply is listed with your Race or 
 Species. See chapter 1: Races if you haven't yet. 
@@ -444,8 +445,8 @@ negative effects.
 
 - Will: defend against a mind affect (Ex: throw off hopelessness after crashing in an escape pod)
 - Shock: maintain composure after serious damage (Ex: stay conscious after being shot by a high caliber round)
-- Reflex: quickly react to an event (Ex: dodge falling debris, fire at an enemy if they leap from one piece of cover to another)
-- Awareness: knowledge and understanding of surroundings (Ex: realizing someone has walked up behind you)
+- Reflex: React quickly to an event (Ex: dodge falling debris, fire at an enemy if they leap from one piece of cover to another)
+- Awareness: Keep apprised of your surroundings (Ex: realizing someone has walked up behind you)
 
 The equations to calculate your bonuses to Saving Throws are as follows:
 
@@ -464,7 +465,7 @@ peers. These special tallents and abilities are called "Feats". See the
 "Leveling Up Rules" table to see how many feats you get at which levels. Unless 
 otherwise specified, you cannot take a feat more than once.
 
-	There are Five kinds of feats and we'll detail them below;
+	There are five kinds of feats, detailed below;
 
 * Passive Feats
 * Active Feats
@@ -497,9 +498,10 @@ and offer bonuses based on the relevant Weapons skill (Weapon skills are listed
 in "06_Skills.txt"). Each feat offers a set of bonuses related to using that type of 
 weapon (and only that type of weapon), and each bonus requires the character to have 
 a number of points in the relevant Weapon skill. A character with 0 points in 
-Weapons - Pistols would gain only one benefit, while 60 points would benefit from 
-them all. The feats are formatted as a list of "X: Benefit", where X is the number of 
-points required in the corresponding Weapon skill to gain the benefit.
+Weapons - Pistols would gain only one benefit, while a character with 60 points 
+would benefit from them all. The feats are formatted as a list of "X: Benefit", 
+where X is the number of points required in the corresponding Weapon skill to 
+gain the benefit.
 	
 	Weapon Expertise feats require proficiency with the weapon type, but otherwise 
 have no prerequisites. Note that as all characters are proficient with Unarmed 
@@ -507,9 +509,9 @@ Strike, Melee Expertise effectively has no prerequisite.
 
 Primary Stat Feats:
 	
-	Stat Feats are special and cannot be taken when you get a feat like Active
-or Passive Feats. Instead, they are immediately unlocked when you fulfill their
-Luck or Charisma requirement. 
+	Stat Feats are special and cannot be taken when you get a feat like Active,
+Passive, or Weapon Expertise Feats. Instead, they are immediately unlocked when 
+you fulfill their stat requirement. 
 
 Class Feats:
 

--- a/03_Glossary_of_Terms.txt
+++ b/03_Glossary_of_Terms.txt
@@ -19,11 +19,6 @@ measure either of how much armor a weapon can pierce without losing damage to
 the armor, or what level of weapon penetration an armor will completely stop. 
 See the "Other Combat Details" section of Basic Rules for more information.
 
-== Base Stats ==
-    The Base Stats of a Character are Strength, Perception, Fortitude, Charisma, 
-Intelligence, Dexterity and Luck. For more about Base Stats, see the Section 
-"Base Stats" in Basic Rules.txt.
-
 == Compound X ==
     The name of the game! It is also the name of a prison planet in the first 
 campaign run back in 2015 by the game's creator, Taylor Rowland. 
@@ -116,6 +111,11 @@ rules.
 Characters and might play in more than one game. Usually one Player plays one 
 Player Character at a time. 
 
+== Primary Stats ==
+    The Primary Stats of a Character are Strength, Perception, Fortitude, 
+Charisma, Intelligence, Dexterity and Luck. For more about Primary Stats, see 
+the Section "Primary Stats" in Basic Rules.
+
 == RPG ==
     Role-Playing Game, such as Dungeons and Dragons or Compound X!
 
@@ -165,6 +165,11 @@ Reactions occur at the immediate moment that they are triggered. See "Reactions
     A Saving Throw is a roll of the dice to see whether your character has the 
 defenses to avoid something bad happening to them. See "Saving Throws" in the 
 Basic Rules.txt document for more information.
+
+== Secondary Stats ==
+    Secondary Stats are Carry Ability, Movement Speed and Skill Point Gain. 
+These stats are determined by your Primary Stats. For more information on 
+Secondary Stats, see the "Secondary Stats" section of the Basic Rules.
 
 == Shield Strength ==
     Shield Strength is a measure of how much damage a personal shield can take

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -1,12 +1,8 @@
 ==============================
-Notes
+Feats
 ==============================
+
     This document lists the feats available to characters in Compound X.
-Feats may be taken on every even level as described in the Basic
-Rules document. Passive feats are used freely with no limit
-(unless otherwise stated) while active feats require the user to
-spend some Nanites, which is specified next to the feat's name.
-Unless otherwise specified, you cannot take a feat more than once.
 
 ==============================
 Passive Feats
@@ -716,19 +712,6 @@ now working with. This feat can only be taken once per weapon.
 ==============================
 Weapon Expertise Feats:					
 ==============================
-		
-	These feats represent dedicated training with a particular class of weapon, 
-and offer bonuses based on the relevant Weapons skill (Weapon skills are listed 
-in "06_Skills.txt"). Each feat offers a set of bonuses related to using that type of 
-weapon (and only that type of weapon), and each bonus requires the character to have 
-a number of points in the relevant Weapon skill. A character with 0 points in 
-Weapons - Pistols would gain only one benefit, while 60 points would benefit from 
-them all. The feats are formatted as a list of "X: Benefit", where X is the number of 
-points required in the corresponding Weapon skill to gain the benefit.
-	
-	Weapon Expertise feats require proficiency with the weapon type, but otherwise 
-have no prerequisites. Note that as all characters are proficient with Unarmed Strike, 
-Melee Expertise effectively has no prerequisite.
 
 == Pistol Expertise ==	
 


### PR DESCRIPTION
added Primary and Secondary Stats to glossary
removed some feats rules from feats document, added feats section to basic rules
re-wrote secondary stats section
fixed b0rk'd headings not diplaying properly

More work is yet to be done; in particular, the character creation section is still duplicated. But I figured this already had enough scope creep to get bogged, so I'll continue in another PR.
	modified:   01_01_Basic_Rules.txt
	modified:   03_Glossary_of_Terms.txt
	modified:   CharacterCreation/03_Feats.txt