### PR TITLE
Adding the Whackbush Arms Spear, a lv 1 2-h weapon

### DIFF
--- a/Items/04_01_Melee_&_Thrown_Weapons.txt
+++ b/Items/04_01_Melee_&_Thrown_Weapons.txt
@@ -77,6 +77,18 @@ Range: Adjacent (1m)
 Accuracy Modifier: +2
 DEX Requirement: 4
 
+== Whackbush Arms Mark 14 C-Fiber 6ft Hunting Spear $820 ==
+
+Damage: 40 + 3*STR mod + 1*DEX mod Ballistic
+Size: Two-handed
+Range: Adjacent (1m)
+Accuracy Modifier: +2
+DEX Requirement: 2
+
+	If you down an enemy with this weapon without a critical hit, 
+you must spend an Action to remove it from the target before you can 
+attack with it again.
+
 ===== Level 5 Requirement Weapons =====
 
 == Eliazar Plasma Torch $240 ==


### PR DESCRIPTION
Price is pretty arbitrary.
Damage numbers come out to 84 with 7Str and 7Dex and 120 with 9Str and 7Dex.

Drawback comes from concerns about the lv 1 damage potential, and in particular oneshotting unarmored enemies. It may be removed later to be replaced with a more general drawback for two-handers.

solves the gripe portion of #711