### PR TITLE
Medicalize Adrenaline Rush

### DIFF
--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -904,6 +904,17 @@ Prerequisites:
 for that action only. This feat can only be used once per turn.
 Adrenaline Rush can be taken again to reduce the Nanite cost to 2*X.
 
+== Adrenaline Rush ==
+
+Prerequisites:
+
+*  None
+
+Cooldown: X Rounds, max 2
+Duration: Free Action
+
+	During your next move action this turn, you may an additional 4 * X meters.
+
 == Aimed Shot [8 Nanites] ==
 Prerequisites:
 

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -895,15 +895,6 @@ you are wielding an appropriate weapon.
 Active Feats
 ==============================
 
-== Adrenaline Rush [4*X Nanites] ==
-Prerequisites:
-
-*  None
-
-	During a move action, +1 movement speed per X (up to a max of +10 movement),
-for that action only. This feat can only be used once per turn.
-Adrenaline Rush can be taken again to reduce the Nanite cost to 2*X.
-
 == Adrenaline Rush ==
 
 Prerequisites:


### PR DESCRIPTION
Some functional change to adrenaline rush during the conversion.
Now only gives either +4 of +8 instead of anything between +1 and +10.
Also removed the take-the-feat-twice-to-halve-the-cost, but I could be persuaded to restore that.