### PR TITLE
Medicalize Cover Slide

### DIFF
--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -934,14 +934,19 @@ the action after this feat ends. If this malus would not run out until after
 this turn, its effect wraps, around to the beginning of your next turn. Cannot 
 be used in concert with Run 'N' Gun.
 
-== Cover Slide [15 Nanites] ==
+== Cover Slide ==
+
 Prerequisites:
 
 *  DEX 4
 
-	Move up to your speed and end next to a barrier behind which you can take
-cover. You hunker or go prone behind that cover as a free action. Cannot 
-be used in concert with Run 'N' Gun.
+Cooldown: None
+Duration: 2 Actions
+
+	You move up to your speed in meters and become prone. If you have a cover 
+bonus in your new location, you may hunker instead of going prone. Attacks made 
+against you during the use of Cover Slide have -1 Accuracy. Cover Slide cannot be 
+used at the same time as Run 'N' Gun.
 
 == Flash Dance [10*X Nanites] ==
 Prerequisites:

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -943,10 +943,11 @@ Prerequisites:
 Cooldown: 1 Round
 Duration: 1 Action
 
-	You move up to your movement speed in meters and become prone. If you 
-have a cover bonus in your new location, you may hunker instead of going prone. 
-Attacks made against you during the use of Cover Slide have -1 Accuracy. Cover 
-Slide cannot be used at the same time as Run 'N' Gun.
+	Choose a location up to your movement speed in meters away that contains 
+something solid enough to stop your headlong slide. You move to that location and 
+either go prone or hunker somewhere in that square (you choose). Attacks made 
+against you during the use of Cover Slide have -1 Accuracy. Cover Slide cannot be 
+used at the same time as Run 'N' Gun.
 
 == Flash Dance ==
 

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -940,13 +940,13 @@ Prerequisites:
 
 *  DEX 4
 
-Cooldown: None
-Duration: 2 Actions
+Cooldown: 1 Round
+Duration: 1 Action
 
-	You move up to your speed in meters and become prone. If you have a cover 
-bonus in your new location, you may hunker instead of going prone. Attacks made 
-against you during the use of Cover Slide have -1 Accuracy. Cover Slide cannot be 
-used at the same time as Run 'N' Gun.
+	You move up to your movement speed in meters and become prone. If you 
+have a cover bonus in your new location, you may hunker instead of going prone. 
+Attacks made against you during the use of Cover Slide have -1 Accuracy. Cover 
+Slide cannot be used at the same time as Run 'N' Gun.
 
 == Flash Dance [10*X Nanites] ==
 Prerequisites:


### PR DESCRIPTION
Some functional changes here. 
* Now does not require that you end in a space with cover, to make tracking easier for the DM.
* Now consumes two actions instead of one, to avoid slapping a huge cooldown on it.
* Now gives an evasion bonus to compensate for the above. Useful for dodging readied shots and light suppression when moving between covers.

General note on Active Feats with a cooldown of None: I gave this to a few of them, generally because I'm not concerned about multiple uses per round (in the case of cover slide, it would be really hard to do so at all. The intention is that the Cooldown: None feats still require you to have a unit of medi nanites available and off cooldown., it just doesn't then send them into any remission.