### PR TITLE
Medicalize Flash Dance

### DIFF
--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -943,16 +943,21 @@ Prerequisites:
 cover. You hunker or go prone behind that cover as a free action. Cannot 
 be used in concert with Run 'N' Gun.
 
-== Flash Dance [10*X Nanites] ==
+== Flash Dance ==
+
 Prerequisites:
 
 *  Level 3
 
-	For 2 Actions, the user can make Lvl/2 (round up) number of attacks, up to a 
-max of 6, with their melee weapon(s). The attacks must take place within a 5m 
-space, rolling for each strike, where X is the number of attacks. All bonuses 
-that would normally apply to a standard attack still apply. (Note: Flash Dance 
-can trigger Bulltrue and Preemptive Strike)
+Cooldown: 2 * X + 1 Rounds
+Duration: 2 * X Actions, up to X = 3
+
+	For the duration of Flash Dance, every 2 Actions you may instead make a 
+number of Melee Attacks, Trip, Disarm, or Kick attempts equal to your level divided 
+by 2 (rounding up), to a maximum of 6. These actions have a range of 2m. Roll 
+separately for each act. All bonuses that would normally apply to a standard attack 
+still apply. (Note: Flash Dance can trigger Bulltrue and Preemptive Strike). If you 
+are stunned or rendered unconscious, Flash Dance ends immediately.
 
 == Gun Kata [30 Nanites] ==
 Prerequisites:


### PR DESCRIPTION
Spin to win?

Hoo-kay, I tried to fix this one while I was in here. Here's what I changed:
* Now has a duration between 2 and 6 actions, instead of 1 action. Cooldown scales to duration.
* Range of flash dance reduced from  '"a 5m space" that you could be adjacent to' to a 2m radius centered on the user
* In compensation for the range nerf, I've allowed the use of several combat maneuvers in addition to attacks. I specifically left out the ones that require the user to move, and also grapple because that would end the flash dance.
* added explicit flash dance termination due to stun.