### PR TITLE
Medicalize Kip Up

### DIFF
--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -975,11 +975,15 @@ additional attacks, where X is your Nanites spent/5. Each additional attack has 
 compounding -2 accuracy. (A 10th level character making their 3rd strike in a 
 row would be rolling at -4 accuracy).
 
-== Kip-up [15 Nanites] ==
+== Kip-up ==
+
 Prerequisites:
 
 * DEX 6
 * STR 5
+
+Cooldown: See Below
+Duration: Free Action
 
 	A Kip-up is a gymnastic maneuver in which a character lying on the ground
 curls up and then kicks up and out into the air, using the resulting momentum to 
@@ -987,14 +991,14 @@ jump from their back straight to their feet. This kick does not work well as a
 melee attack; the momentum is used to move the kicker rather than to impart 
 impact unto a target.
 
-	You may jump up from the prone to the standing position as a Free Action. 
-This action cannot be taken to go straight from prone to crouched. Further, if 
-the transition from prone to standing to crouched is taken, the normally Free
-Action of going from standing to crouched costs an Action. The kip-up cannot be
-attempted with Heavy or Full Armor on. The kip-up can only be done once every
-three rounds, but doesn't cost any nanites to do. The Three-round cooldown can
-be ignored once per round by paying the nanite cost.
+	You jump up from the prone to the standing position. This action cannot 
+be taken to go straight from prone to crouched. Further, if you would crouch 
+this turn, the normally Free Action of going from standing to crouched costs 
+an Action. You cannot kip-up while wearing Heavy, Full, or Power Armor, or in 
+a microgravitic environment.
 
+	Kip-up may be used without a cooldown once every 3 rounds. Kipping Up 
+less than 3 Rounds after your last one incurs a 3 Round cooldown.
 
 == Multi-Target [13*X Nanites] ==
 Prerequisites:


### PR DESCRIPTION
An interesting one, to be sure. Had to preserve the unique cooldown structure, because it's great.

Changelog:
* Now cannot kip up in microgravity. Because you don't need a feat to do that.
* Now also cannot kip up in power armor. It doesn't exist yet, but one day... (I'm, sure we'll make a module that lets the power armor kip up, but we can call it Powered Kip Up or something)
* The 3 round cooldown is harsher than I would normally apply, but I think that it will help with tracking. This feat has more than its fair share of tracking complexity already.