### PR TITLE
Medicalize Run 'N Gun

### DIFF
--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -1008,7 +1008,8 @@ Targets. You may Roll to-hit your first target in order to determine if you hit
 all of these targets. If you fail the roll, then you may roll again to hit your 
 first target normally.
 
-== Run 'N' Gun [10 Nanites] ==
+== Run 'N' Gun ==
+
 Prerequisites:
 
 *  PER 7
@@ -1016,11 +1017,14 @@ Prerequisites:
 *  or Soldier Class
 *  or Specialist Class
 
-	For 1 Action, you may move at half speed while firing. -1 to accuracy. If 
-you don't Aim before using this feat, you must Hip Fire. If this feat is 
-performed while sprinting, half your movement speed before you add the +1m 
-per-action from sprinting. The Miss Chance penalties stack for consecutive uses 
-of Run 'N' Gun. 
+Cooldown: X / 2 Rounds, min 1
+Duration: X Actions, maximum 4
+
+	You move at half speed while firing your firearm. Each attack has a cumulative 
+-1 Accuracy penalty but can benefit from a previous Aim action (otherwise Hip Fire 
+rules apply as normal). You may use this feat in combination with sprinting; if you 
+do, halve your movement speed before you add sprinting modifiers. 
+
 
 == Steady Shot [5 Nanites] ==
 Prerequisites:


### PR DESCRIPTION
Wording changes, mostly ordering.
Ever so slightly significant change in that Running and Gunning for 3 actions is now one use of the feat instead of 3 uses, but that made the cooldown a lot less snarly.