### PR TITLE
Nanite Aesthetic terminology in Disrupted

### DIFF
--- a/01_05_Conditions.txt
+++ b/01_05_Conditions.txt
@@ -46,7 +46,7 @@ below 0. See the "Death and Dying" section in the Combat Rules Document.
 signal jamming, malware or sometimes direct electrical interference. When this
 succeeds, it prevents their target from using their more exotic talents.
 
-    A Character that is Disrupted cannot use Nanite abilities, Doctor Procedures, 
+    A Character that is Disrupted cannot use Active Feats, Doctor Procedures, 
 Engineer Processes or Hacker Exploits. Many similar abilities are also prone to 
 Disruption. If they are not on this list, consult your GM. 
 


### PR DESCRIPTION
Convert "nanite abilities" to "active feats", since those are the only nanite abilities left once the nanite superbranch merges. I'm making this change in dev instead of there because the updated flavor text postdates the superbranch's creation and it has enough merge conflicts already.