### PR TITLE
Turtlelord26 Static Armor Superbranch -> dev

### DIFF
--- a/Combat Rules/3_Melee_Combat.txt
+++ b/Combat Rules/3_Melee_Combat.txt
@@ -35,8 +35,8 @@ aimed at the target, standard Hip Firing rules apply.
     Melee attackers make accuracy rolls with a d10, increased by strength and 
 dexterity combat modifiers and their weapon's accuracy modifier. To successfully 
 hit, the result must be greater than (not equal to) the opponent's Guard roll. 
-If you successfully hit your opponent, armor applies as normal except as 
-detailed in the next two topics.
+If you successfully hit your opponent, armor applies as detailed in the next 
+two topics.
 
     Defending players roll Guard with a d10 as well, increased by fortitude 
 and dexterity combat modifiers and their weapon's guard bonus. Guard bonuses are 
@@ -71,16 +71,14 @@ Hacker terminal, and similar devices.
 
 == Hitting What You Intend ==
 
-    If you roll 3 or more above your target's Guard, you may ignore any 
-armor worn by the target and damage health directly.
+    Similarly to ranged weapon attacks, if your melee Accuracy roll 
+exceeds the target's Guard roll by more than the target's armor's Coverage, 
+you may bypass the target's armor and damage health directly.
     
 == Stealth Attacks in Melee Combat ==
 
-    If you stealth-attack a target with a melee attack, your target has a Guard 
-of 0. Recall that if you roll 3+ above the opponent's Guard, you ignore the 
-opponent's armor and deal full damage. This signifies that the target gets hit 
-in whatever you deem to be the most vulnerable; i.e., the head, neck, or the 
-chest (over the heart, etc).
+    If you stealth-attack a target with a melee attack, your target is 
+considered to have a Guard of 0 for your first attack (they do not roll).
 
 == Blunt Force ==
 
@@ -96,10 +94,10 @@ attack was a two-handed strike, the health damage would be 18.
 == Nonlethal Damage ==
 
     By default, melee attacks deal lethal damage, like the vast majority of 
-guns. This just means that when an attack drops a target to 0 health, they 
+other weapons. This just means that when an attack drops a target to 0 health, they 
 enter the Bleeding Out state. However, when fighting unarmed or with a melee 
 weapon that you are proficient with, you may declare a melee attack you have 
-not yet rolled to be nonlethal. This imposes a -2 accuracy penalty, since you are 
+not yet rolled to be nonlethal. This gives you a -2 accuracy penalty, since you are 
 imposing constraints upon yourself on where you can strike, but if a nonlethal 
 attack would reduce a target to 0 health, the target drops to 0 health and becomes
 Unconscious instead of becoming Downed and beginning to Bleed Out. The Unconscious

--- a/Combat Rules/4_Armor_Rules.txt
+++ b/Combat Rules/4_Armor_Rules.txt
@@ -23,9 +23,9 @@ improves the Armor Coverage (% of Armor protection), but not the quantity of
 the Armor Strength (AS) or the Armor Piercing Level (APL). 
 
     For example: if you purchase a Chest Rig from the Medium Armor Systems
-category and a Standard L1 Material, you'll have 40% coverage, 40 AS, and an 
+category and a Standard L1 Material, you'll have 2 Coverage, 40 AS, and an 
 APL of 1. Now, in addition, if you purchase the Leg Rig from the Medium Armor 
-Systems and a Standard L1 Material, you'd have 55% coverage, 40 AS, and an
+Systems and a Standard L1 Material, you'd have 3 Coverage, 40 AS, and an
 APL of 1.
 
 *Note: you cannot mix-and-match Materials or Rig categories. Only one
@@ -91,12 +91,21 @@ without letting it break, they can avoid the costly recharge time.
 For more information, please see section "Shields" in the 
 Basic Rules document.
 
-    Armor consists of 3 concepts: Armor Points (APs), Armor Piercing level (APL),
-and % Coverage. Starting from the end, Coverage is simply the percentile that 
-you have to roll under to see if armor was hit. If the attack misses armor, or 
-rolls over 50%, it does half damage because the bullet is hitting a less vital 
-part of the body. If the attack hits armor: Armor Piercing level (APL) comes 
-into play.
+===== Armor Attributes =====
+
+== Coverage ==
+
+    Coverage is a number that represents how effective the armor is 
+at taking fire. Whenever character makes a ranged attack against a target 
+in armor, the attacker rolls Accuracy, applies any applicable bonuses, 
+subtracts cover modifiers, the weapon's base miss chance, and other 
+penalties, and states the result. If that number is less than or equal 
+to the defender's Coverage, the attack strikes armor (first). If it is 
+greater, the attack bypasses the armor. When an attack strikes armor, the 
+next two attributes are involved.
+
+    For Laser, Electric, and other damage types that armor cannot absorb, 
+the armor is considered to have a Coverage of 0.
 
 == Armor Piercing Level (APL) ==
 

--- a/Items/05_Armors.txt
+++ b/Items/05_Armors.txt
@@ -14,19 +14,19 @@ available to characters in standard campaigns.
 ----Chest Rig ----
 Rig Cost:		400
 Magazine Space:		5 (No more than 1 grenade per 3 secondary ammunition space)
-Armor Coverage:		40% 
+Armor Coverage:		2 
 Movement Speed Penalty: -2m
 
 ----Arm Rig (*No Armor*) ----
 Rig Cost:		90
 Magazine Space: 	(2 Secondary Magazines)
-Armor Coverage:		n/a
+Armor Coverage:		0
 Movement Speed Penalty: 0	
 
 ----Leg Rig (*No Armor*) ----
 Rig Cost:		120
 Magazine Space:		2
-Armor Coverage:		n/a
+Armor Coverage:		0
 Movement Speed Penalty: 0
 
 == ADVANCED RIGS ==
@@ -34,7 +34,7 @@ Movement Speed Penalty: 0
 ----Advanced Chest Rig ----
 Rig Cost:		790
 Magazine Space:		4 (No more than 1 grenade per 3 secondary ammunition space)
-Armor Coverage:		30% 
+Armor Coverage:		2 
 Hard Points:    	2
 Movement Speed Penalty: -2m
     
@@ -46,19 +46,19 @@ Movement Speed Penalty: -2m
 ----Chest Rig ----
 Rig Cost:		570
 Magazine Space:		6 + (1 Additional Secondary Magazine or Grenade)
-Armor Coverage:		40% 
+Armor Coverage:		2 
 Movement Speed Penalty: -2m
 
 ----Arm Rig (*No Armor*) ----
 Rig Cost:		90
 Magazine Space: 	(2 Secondary Magazines or Grenades)
-Armor Coverage:		n/a
+Armor Coverage:		0
 Movement Speed Penalty: 0
 
 ----Leg Rig ----
 Rig Cost:		260
 Magazine Space:		2	
-Armor Coverage:		15% 
+Armor Coverage:		1 
 Movement Speed Penalty: 0
 
 == ADVANCED RIGS ==
@@ -66,21 +66,21 @@ Movement Speed Penalty: 0
 ----Advanced Chest Rig ----
 Rig Cost:		790
 Magazine Space:		5 + (1 Additional Secondary Magazine or Grenades)
-Armor Coverage:		35% 
+Armor Coverage:		2 
 Hard Points:    	1
 Movement Speed Penalty: -2m
 
 ----Advanced Arm Rig (*No Armor*) ----
 Rig Cost:		130
 Magazine Space: 	0
-Armor Coverage:		n/a
+Armor Coverage:		0
 Hard Points:    	1
 Movement Speed Penalty: 0
 
 ----Advanced Leg Rig ----
 Rig Cost:		320
 Magazine Space:		0	
-Armor Coverage:		15% 
+Armor Coverage:		1 
 Hard Points:    	1
 Movement Speed Penalty: 0
     
@@ -92,19 +92,19 @@ Movement Speed Penalty: 0
 ----Chest Rig ----
 Rig Cost:		760
 Magazine Space:		8 + (2 Additional Secondary Magazines or Grenades)
-Armor Coverage:		40% 
+Armor Coverage:		2 
 Movement Speed Penalty: -2m
 
 ----Arm Rig ----
 Rig Cost:		220
 Magazine Space: 	(2 Secondary Magazines or Grenades)
-Armor Coverage:		10%
+Armor Coverage:		1
 Movement Speed Penalty: 0
 
 ----Leg Rig ----
 Rig Cost:		290
 Magazine Space:		2	
-Armor Coverage:		15% 
+Armor Coverage:		1 
 Movement Speed Penalty: 0
 
 == ADVANCED RIGS ==
@@ -112,21 +112,21 @@ Movement Speed Penalty: 0
 ----Advanced Chest Rig ----
 Rig Cost:		1020
 Magazine Space:		7
-Armor Coverage:		35% 
+Armor Coverage:		2 
 Hard Points:    	1
 Movement Speed Penalty: -2m
 
 ----Advanced Arm Rig ----
 Rig Cost:		330
 Magazine Space: 	0
-Armor Coverage:		10%
+Armor Coverage:		1
 Hard Points:    	1
 Movement Speed Penalty: 0
 
 ----Advanced Leg Rig ----
 Rig Cost:		370
 Magazine Space:		0	
-Armor Coverage:		15% 
+Armor Coverage:		1 
 Hard Points:    	1
 Movement Speed Penalty: 0
 	
@@ -140,20 +140,20 @@ provide a bonus +10 Armor Strength.
 ----Chest Rig ----
 Rig Cost:		1000
 Magazine Space:		10
-Armor Coverage:		40% 
+Armor Coverage:		3 
 Movement Speed Penalty: -2m
 Notes: Provides an additional +10 Armor Strength
 
 ----Arm Rig ----
 Rig Cost:		320
 Magazine Space: 	1
-Armor Coverage:		15%
+Armor Coverage:		1
 Movement Speed Penalty: -0.5m
 
 ----Leg Rig ----
 Rig Cost:		390
 Magazine Space:		2	
-Armor Coverage:		20% 
+Armor Coverage:		1 
 Movement Speed Penalty: -0.5m
 
 == ADVANCED RIGS ==
@@ -161,7 +161,7 @@ Movement Speed Penalty: -0.5m
 ----Advanced Chest Rig ----
 Rig Cost:		1860
 Magazine Space:		8
-Armor Coverage:		35% 
+Armor Coverage:		2 
 Hard Points:    	2
 Movement Speed Penalty: -2m
 Notes: Provides an additional +10 Armor Strength
@@ -169,14 +169,14 @@ Notes: Provides an additional +10 Armor Strength
 ----Advanced Arm Rig ----
 Rig Cost:		460
 Magazine Space: 	0
-Armor Coverage:		15%
+Armor Coverage:		1
 Hard Points:    	1
 Movement Speed Penalty: -0.5m
 
 ----Advanced Leg Rig ----
 Rig Cost:		500
 Magazine Space:		0	
-Armor Coverage:		20% 
+Armor Coverage:		1 
 Hard Points:    	1
 Movement Speed Penalty: -0.5m
 
@@ -190,20 +190,20 @@ of your legs. Heavy Armor Chest Rigs provide a bonus +20 Armor Strength.
 ----Chest Rig ----
 Rig Cost:		1220
 Magazine Space:		12
-Armor Coverage:		40% 
+Armor Coverage:		3 
 Movement Speed Penalty: -2m
 Notes: Provides an additional +20 Armor Strength
 
 ----Arm Rig ----
 Rig Cost:		410
 Magazine Space: 	1
-Armor Coverage:		25%
+Armor Coverage:		1
 Movement Speed Penalty: -1m
 
 ----Leg Rig ----
 Rig Cost:		590
 Magazine Space:		3	
-Armor Coverage:		35% 
+Armor Coverage:		2 
 Movement Speed Penalty: -1m
 
 == ADVANCED RIGS ==
@@ -211,7 +211,7 @@ Movement Speed Penalty: -1m
 ----Advanced Chest Rig ----
 Rig Cost:		2170
 Magazine Space:		9
-Armor Coverage:		35% 
+Armor Coverage:		3 
 Hard Points:    	2
 Movement Speed Penalty: -2m
 Notes: Provides an additional +20 Armor Strength
@@ -219,14 +219,14 @@ Notes: Provides an additional +20 Armor Strength
 ----Advanced Arm Rig ----
 Rig Cost:		590
 Magazine Space: 	0
-Armor Coverage:		25%
+Armor Coverage:		1
 Hard Points:    	1
 Movement Speed Penalty: -1m
 
 ----Advanced Leg Rig ----
 Rig Cost:		690
 Magazine Space:		0	
-Armor Coverage:		35% 
+Armor Coverage:		2 
 Hard Points:    	1
 Movement Speed Penalty: -1m
 
@@ -242,21 +242,21 @@ Cost:	$100
 	
 Gunner Kit:
 Cost:	$231
-- Trauma Plate Vest. Holds 1 trauma plate in the front. 30% Coverage, must 
+- Trauma Plate Vest. Holds 1 trauma plate in the front. 1 Coverage, must 
   purchase Armor Material separately (purchase a single Armor Material at Chest 
   Armor cost). Concealable. 
 - Conceal Rig, Shoulder Harness. Pistol Holster, 2 Pistol mags.
 
 Enforcer Kit:
 Cost:	$306
-- Trauma Plate Vest. Holds 1 trauma plate in the front. 30% Coverage, must 
+- Trauma Plate Vest. Holds 1 trauma plate in the front. 1 Coverage, must 
   purchase Armor Material separately (purchase a single Armor Material at Chest 
   Armor cost). Concealable. 
 - Conceal Rig, Waist. Pistol Holster or 2 primary mags,2 secondary mags.
 
 Clandestine Ops Kit:
 Cost:	$341
-- Trauma Plate Vest. Holds 1 trauma plate in the front. 30% Coverage, must 
+- Trauma Plate Vest. Holds 1 trauma plate in the front. 1 Coverage, must 
   purchase Armor Material separately (purchase a single Armor Material at Chest 
   Armor cost). Concealable. 
 - Conceal Rig, Waist. Pistol Holster or 2 Primary Mags, 2 Secondary Mags. 
@@ -289,14 +289,14 @@ Cost:	$800
 Suit integrity: 5 shots
 	Basic Environment Suit, offers minimal ballistic protection. When shot, 
 the suit will decompress or compress as necessary to maintain air pressure.
-Holds 1 trauma (Armor Material) plate in the front and back. 30% coverage, must purchase 
+Holds 1 trauma (Armor Material) plate in the front and back. 1 Coverage, must purchase 
 Armor material separately (purchase a single Armor Material at Chest Armor cost).
 
 =====   LEVEL 5 REQUIREMENT   =====
 	
 Polymer-Alloy Environment Suit
 Cost:	$1200
-	Holds 1 trauma (Armor Material) plate in the front and back. 30% coverage, must 
+	Holds 1 trauma (Armor Material) plate in the front and back. 1 Coverage, must 
 purchase Armor material separately (purchase a single Armor Material at Chest Armor cost).
 Suit integrity: 10 shots
 
@@ -305,12 +305,13 @@ Suit integrity: 10 shots
 Kevlar Fiber Environment Suit
 Cost:	$2000
 Suit integrity: 20 shots
-	Holds 1 trauma (Armor Material) plate in the front and back. 30% coverage, must 
+	Holds 1 trauma (Armor Material) plate in the front and back. 1 Coverage, must 
 purchase Armor Material separately (purchase a single Armor Material at Chest Armor cost).
 	
 ==============================
 STANDARD BALLISTIC ARMOR MATERIALS
 ==============================
+
 	Adding any Armor Materials to a Chest, Leg, or Arm Rig adds to your 
 movement speed penalties by -1m per Material added. The secondary stat,
 "Carry Strength", cancels out movement speed penalties; for more information,


### PR DESCRIPTION
Look I wrote it down 🐢. I remembered we don't need a test session before merging to dev.

The updated character sheet will be my greatest ally in explaining to players how the new armor works @Reveraine. Is there room for a grid that decomposes the relevant armor attributes by rig part and provides a "total" box? 🐇🕳

Static Armor is in essence a surprisingly simple shift. All armor Coverage values have been converted from percentages to integers. Functionally, the new integer Coverage values are just another modifier to attack rolls make against armored characters. Most important part of the PR is the Armor Coverage section in the armor rules subdocument of combat rules.