### PR TITLE
Name-change to Dark Vision trait

### DIFF
--- a/CharacterCreation/01_04_Species_Opaleites.txt
+++ b/CharacterCreation/01_04_Species_Opaleites.txt
@@ -119,9 +119,9 @@ turning head]
 
 ===== Available Traits =====
 
-Dark Vision:
+Light-gathering Retina:
     The water on any given planet is not always brightened heavily by the sun. 
-Acclimated to darker waters, many Opalites can see as if in normal light in
+Acclimated to darker waters, many Opaleites can see as if in normal light in
 low light conditions.
 
 ==============================


### PR DESCRIPTION
Now no longer potentially confuses DnD players used to rolling up Drow PCs.