### PR TITLE
Rework of Light Dance

### DIFF
--- a/CharacterCreation/01_04_Species_Opaleites.txt
+++ b/CharacterCreation/01_04_Species_Opaleites.txt
@@ -223,9 +223,9 @@ experienced individual can alternate lighting scales from tip to tail to
 misdirect an enemy.
 
    Under low-light or darker conditions, if you moved at least your move speed 
-on your last turn, enemies must pass a DC 60 Perception check in order to Aim
-at you (they may try multiple times). Enemies using nonvisible light, such as IR 
-goggles, are unaffected.
+on your last turn, then whenever an enemy would Aim at you, they must pass a 
+DC 60 Perception check to successfully do so. Enemies using nonvisible light 
+equipment, such as IR goggles, are unaffected.
    
 Deep Glow:
 

--- a/CharacterCreation/01_04_Species_Opaleites.txt
+++ b/CharacterCreation/01_04_Species_Opaleites.txt
@@ -222,11 +222,9 @@ confuse enemies. Used in conjunction with darkness and quick movement, an
 experienced individual can alternate lighting scales from tip to tail to 
 misdirect an enemy.
 
-   Under low-light or darker conditions, you may use this ability while evading 
-enemy fire to give enemies attacking you a -1 to accuracy. Enemies may roll a DC 
-60 Awareness Save to see throught the deception. May also be used to attempt to 
-distract an individual away from your teammates; enemy Awareness vs. Acrobatics 
-(Dex) or Athletics (Dex).
+   Under low-light or darker conditions, if you moved at least your move speed 
+on your last turn, enemies using sight to target you have a -1 penalty to 
+ranged accuracy while attacking you. 
    
 Deep Glow:
 

--- a/CharacterCreation/01_04_Species_Opaleites.txt
+++ b/CharacterCreation/01_04_Species_Opaleites.txt
@@ -223,8 +223,9 @@ experienced individual can alternate lighting scales from tip to tail to
 misdirect an enemy.
 
    Under low-light or darker conditions, if you moved at least your move speed 
-on your last turn, enemies using sight to target you have a -1 penalty to 
-ranged accuracy while attacking you. 
+on your last turn, enemies must pass a DC 60 Perception check in order to Aim
+at you (they may try multiple times). Enemies using nonvisible light, such as IR 
+goggles, are unaffected.
    
 Deep Glow:
 


### PR DESCRIPTION
Subject to debate.

Removed "may be used to distract..." as that can be implied (so we don't need the extra text) and players will feel better about coming up with it on their own.
Removed that enemies may roll to negate the accuracy penalty over complexity and combat slowdown concerns.

Reworded ability to clarify what "while evading enemy fire" means. Now in effect if you moved at least your move speed on your previous turn. Slight nerf, hopefully makes up for removing the save.