### PR TITLE
Turtlelord26 GravTech Updates!

### DIFF
--- a/CharacterCreation/02_Classes.txt
+++ b/CharacterCreation/02_Classes.txt
@@ -851,9 +851,8 @@ Range: 1m
 Gravity Dagger:
 	You have miniaturized gravity blade technology into a module that can be held 
 in one hand. This is a separate device from the gravity projector and cannot be wielded 
-simultaneously with one. Gravity daggers can be dual-wielded. Increase the damage of 
-your gravity bayonet by 20. Attacks with gravity melee weapons use the INT combat modifier 
-instead of STR.
+simultaneously with one. Increase the damage of your gravity bayonet by 20. Attacks with 
+gravity melee weapons use the INT combat modifier instead of STR.
 
 Damage: 30 + 2*INT + 2*DEX Internal
 Size: Exotic - Light

--- a/CharacterCreation/02_Classes.txt
+++ b/CharacterCreation/02_Classes.txt
@@ -842,7 +842,7 @@ generate a spike of intense gravity extending out from your projector. The Bayon
 an exotic melee weapon that you are considered proficient with, takes one Action to 
 activate, and costs 8 Gravitons per turn to maintain. You do not have to make Will saves 
 to maintain the Bayonet after taking damage, and may dismiss it on your turn as a free 
-action.
+action. Attacks with gravity melee weapons use the INT combat modifier instead of STR.
 
 Damage: 30 + 2*INT + DEX Internal
 Size: Exotic - Two-handed
@@ -852,7 +852,8 @@ Gravity Dagger:
 	You have miniaturized gravity blade technology into a module that can be held 
 in one hand. This is a separate device from the gravity projector and cannot be wielded 
 simultaneously with one. Gravity daggers can be dual-wielded. Increase the damage of 
-your gravity bayonet by 20.
+your gravity bayonet by 20. Attacks with gravity melee weapons use the INT combat modifier 
+instead of STR.
 
 Damage: 30 + 2*INT + 2*DEX Internal
 Size: Exotic - Light

--- a/CharacterCreation/02_Classes.txt
+++ b/CharacterCreation/02_Classes.txt
@@ -761,22 +761,28 @@ Passives:
 
 Class-Specific Resource:
 	Gravity Technicians spend units of Gravitons to execute their Techniques. 
-Their Microassembly Core is capable of storing 100 units of these captive gravitons, 
-and refills up to 100 units each Long Rest. These capabilities may be increased by 
-acquiring and installing Microassembly Peripherals. Gravity Technicians must track 
-their supply of Gravitons as they would their Health.
+Their Microassembly Core stores and generates units of these captive gravitons.
+Gravity Technicians must track their supply of Gravitons as they would their Health 
+and Energy.
 
 Class Equipment and Abilities:
-	At level 1 your character starts with a Handheld Gravity Generator and a 
-Microassembly Core. The Core looks like a large, blockish backpack and contains a 
-swarm of constructor nanites capable of producing the advanced and highly proprietary 
-materials the Technician needs. This swarm cannot survive outside the Core and 
-individual nanites will slag themselves if removed. The Gravity Generator attached to 
-the Core for power and is approximately the size of a large assault rifle, requiring 
+	At level 1 your character starts with an M1-01 Kepler Lake Microassembly 
+Core and your choice of the Mark I Reengineered Gravity Projector or the Series I 
+Reconditioned Gravity Projector. Microassembly cores look like a large, blockish 
+backpacks and contain a swarm of constructor nanites capable of producing the advanced 
+and highly proprietary materials the Technician needs. This swarm cannot survive outside 
+its core and relies on the core's central processor to think; individual nanites will 
+slag themselves if removed from the core's environment. Gravity projectors attach to the 
+Core for power and are approximately the size of a large assault rifle, requiring 
 two hands to wield.
+
+	Microassembly cores have a number of Hard Points that are used for attaching 
+microassembly peripherals, which are modules that enhance a core in a variety of ways. 
+Microassembly peripherals can be attached to armor Hard Points, but armor Hard Point 
+equipment cannot be attached to microassembly core hard points.
 	
-	At level 1 and each time you gain a level, choose a Gravity Technique from 
-the Gravity Technician Ability Tree to gain.
+	At level 1 and each time you gain a level, choose a Technique from the Gravity 
+Technician Ability Tree to gain.
 
 	At level 1, gain the Sphere Field Shape and one other Basic Field Shape of your 
 choice from the Gravity Technician Ability Tree. At levels 4, 7, 10, and 13, choose 
@@ -796,41 +802,59 @@ Skill Proficiencies:
 * Knowledge (Military, Politics, Corporate, or Underworld - Must be the same choice as above)
 
 == Class Feats ==
-	----------------------
-	Remote Construction
+
+Remote Construction:
 	You have learned how to create self-assembling, temporary gravity generators. 
-	Approximately the size of a 20mm grenade, these devices may be deployed at any
-	range you can communicate over. They are controlled wirelessly from your handheld 
-	generator, but have half its range. Whenever you use a Technique, you may choose to 
-	use any combination of your handheld projector and any active remote projectors. 
-	When projecting a technique through multiple generators, each generator must be 
-	using the same field shape, and if applicable, must be directed toward the same 
-	point. Generators must be separated by at least 5 meters to avoid intereference 
-	- any closer and they won't activate.
-	Remote generators last up to 1 minute or 10 rounds of use. Taking any damage, 
-	being moved after activation, or running out of power causes a remote generator 
-	to slag itself.
-	Your Microassembly Core can build one remote generator per Short Rest and three 
-	per Long Rest, and stores up to three at a time.
-	|
-	|
-	V
+Approximately the size of a 20mm grenade, these devices may be deployed at any range 
+you can communicate over, and are equipped for wired and wireless control your 
+projector. They have half of your projector's range. Whenever you use a Technique, you 
+may choose to use any combination of your handheld projector and any active remote 
+projectors. When projecting a technique through multiple generators, each generator 
+must be using the same field shape, and if applicable, must be directed toward the 
+same point. Generators must be separated by at least 5 meters to avoid intereference - 
+any closer and they won't activate.
+	Remote generators last up to 1 minute or 10 rounds of use. Taking any 
+nonenvironmental damage, being moved after activation, or running out of power causes 
+a remote generator to slag itself. Your Microassembly Core can build one remote generator 
+per Short Rest and three per Long Rest, and stores up to three at a time.
+	
+Remote Construction II:
 	Your remote gravity generators now have equal range to your handheld generator.
-	----------------------
-	Gravity Vanguard
+
+Gravity Vanguard:
 	You have learned how to integrate an auxiliary Gravity Generator into your Light 
-	or Medium armor. Gain Proficiency with Medium armor. Once per Round and a 
-	Reaction, you may use your armor's generator to activate a Technique. This 
-	technique must use the Sphere, Hemisphere (centered forward), or Ring 
-	(perpendicular to your body's orientation) Field Shape. Techniques with durations 
-	require your concentration to be maintained; each time you perform strenuous 
-	activity or take damage you must pass a DC 70 Will Save to continue concentrating.
-	|
-	|
-	V
+or Medium armor. Gain Proficiency with Medium armor. Once per Round as a Reaction, you 
+may use your armor's generator to activate a Technique. This technique must use the 
+Sphere, Hemisphere (centered forward), or Ring (perpendicular to your body's orientation) 
+Field Shape. Will saves to maintain a channeled technique generated by your armor are 
+rolled separately from those for your projector.
+	
+Gravity Vanguard II:
 	Your experience using armor-integrated gravity has given you finer control over 
-	its effects. You may apply a nanite treatment to other characters' armor that 
-	will negate the harmful effects (to the wearer) of one of your Techniques. The 
-	treatment costs 10 Gravitons and expires upon use or after a Short or Long Rest. 
-	Applying multiple layers of this treatment to the same equipment has no effect.
-======================================
+its effects. You may apply a nanite treatment to other characters' armor that will negate 
+the harmful effects (to the wearer) of one of your Techniques. The treatment costs 
+10 Gravitons and expires upon use or after a Short or Long Rest. Applying multiple 
+layers of this treatment to the same equipment has no effect.
+
+Gravity Bayonet:
+	You have discovered how to use interference patterns with free gravitons to 
+generate a spike of intense gravity extending out from your projector. The Bayonet is 
+an exotic melee weapon that you are considered proficient with, takes one Action to 
+activate, and costs 8 Gravitons per turn to maintain. You do not have to make Will saves 
+to maintain the Bayonet after taking damage, and may dismiss it on your turn as a free 
+action.
+
+Damage: 30 + 2*INT + DEX Internal
+Size: Exotic - Two-handed
+Range: 1m
+
+Gravity Dagger:
+	You have miniaturized gravity blade technology into a module that can be held 
+in one hand. This is a separate device from the gravity projector and cannot be wielded 
+simultaneously with one. Gravity daggers can be dual-wielded. Increase the damage of 
+your gravity bayonet by 20.
+
+Damage: 30 + 2*INT + 2*DEX Internal
+Size: Exotic - Light
+Range: 1m
+Accuracy Modifier: +2

--- a/CharacterCreation/Class-Specific Documentation/Gravity_Technician_Abilities.txt
+++ b/CharacterCreation/Class-Specific Documentation/Gravity_Technician_Abilities.txt
@@ -59,7 +59,7 @@ Within full range: ± 1/2 Move Speed
 
 Prerequisites: Impeller Field
 
-Graviton Coat: 40
+Graviton Cost: 40
 Duration: Channel - 15 Gravitons / Round
 Range: Standard
 Save: Shock
@@ -90,7 +90,7 @@ Within full range: 1m/Round
 
 Prerequisites: Pull
 
-Graviton Coat: 30
+Graviton Cost: 30
 Duration: 2 Actions
 Range: Standard
 Save: Reflex
@@ -161,7 +161,7 @@ halves the damage.
 
 Prerequisites: Accelerator Field, Level 6
 
-Graviton Coat: 
+Graviton Cost: 
 Duration: Channel - 
 Range: Standard
 Save: Shock
@@ -218,7 +218,7 @@ save at half DC halves the damage.
 
 Prerequisites: Catch Field, Level 6
 
-Graviton Coat: 
+Graviton Cost: 
 Duration: Channel - 
 Range: Personal
 Save: Reflex
@@ -237,7 +237,7 @@ to 1 meter.
 
 Prerequisites: Gravity Sling, Level 6
 
-Graviton Coat: 
+Graviton Cost: 
 Duration: 2 Actions
 Range: Standard
 Save: Reflex
@@ -257,7 +257,7 @@ trajectory is deflected by at leat 90 degrees.
 
 Prerequisites: Gravity Spike, Level 11
 
-Graviton Coat: 
+Graviton Cost: 
 Duration: 2 Actions
 Range: Standard
 Save: See below
@@ -269,7 +269,7 @@ Field Shapes: Beam
 
 Prerequisites: Tidal Shear, Level 11
 
-Graviton Coat: 
+Graviton Cost: 
 Duration: 2 Actions
 Range: Standard
 Save: See below
@@ -319,7 +319,7 @@ checks in place of Athletics checks where appropriate.
 
 Prerequisites: Rappel
 
-Graviton Coat: 
+Graviton Cost: 
 Duration: Channel - 
 Range: Standard
 Save: N/A
@@ -331,7 +331,7 @@ Field Shapes: Beam
 
 Prerequisites: Pull Pulse II, Level 16
 
-Graviton Coat: 
+Graviton Cost: 
 Duration: 2 Actions
 Range: Standard
 Save: Shock
@@ -354,7 +354,7 @@ least 180 degrees to attempt Stasis.
 
 Prerequisites: Gravity Bolt, Level 16
 
-Graviton Coat: 
+Graviton Cost: 
 Duration: 2 Actions
 Range: Standard
 Save: See below
@@ -366,7 +366,7 @@ Field Shapes: Beam
 
 Prerequisites: Tidal Tear, Level 16
 
-Graviton Coat: 
+Graviton Cost: 
 Duration: 2 Actions
 Range: Standard
 Save: See below
@@ -378,7 +378,7 @@ Field Shapes: Beam, Ring, Sector
 
 Prerequisites: Resonance, Level 16
 
-Graviton Coat: 
+Graviton Cost: 
 Duration: Channel - 
 Range: Standard
 Save: Shock
@@ -390,7 +390,7 @@ Field Shapes: Sphere, Hemisphere, Ring
 
 Prerequisites: Gravitic Jump, Level 16
 
-Graviton Coat: 
+Graviton Cost: 
 Duration: Channel - 
 Range: Standard
 Save: N/A

--- a/CharacterCreation/Class-Specific Documentation/Gravity_Technician_Abilities.txt
+++ b/CharacterCreation/Class-Specific Documentation/Gravity_Technician_Abilities.txt
@@ -7,7 +7,7 @@ A Note on Terminology:
 not meant to imply largeness or heaviness. It means only that the 
 referenced object has mass, and is thus affected by gravity.
 
-== Gravity Technique Ranges ==
+== Gravity Technique General Notes ==
 
 	Gravity Projectors have a maximum range at which they can exert 
 noticeable force. When using a Technique with Weapon range, the Technician 
@@ -19,10 +19,6 @@ not the maximum range possible.
 	Some techniques have Personal range, which means that they only 
 apply effects within the user's square except as otherwise stated.
 
-	For Techniques that allow targets to make a Save to mitigate 
-effects, the base DC is given by the Gravity Projector and may be modified 
-by microassembly cores or peripherals.
-
 	Techniques that require Channeling take 2 Actions to activate and 
 cost 2 Actions each subsequent turn that the ability is maintained. The 
 user may move and take other Actions while channeling, but cannot use 
@@ -31,6 +27,16 @@ GravTech who takes more than 80 damage in an Action must make a Will save
 with DC equal to half the damage taken to maintain the technique; on failure 
 the channel stops. The user may stop the channel any time on their turn 
 as a Free Action.
+
+	For Techniques that allow targets to make a Save to mitigate 
+effects, the base DC is given by the Gravity Projector and may be modified 
+by microassembly cores or peripherals.
+
+	Gravitic effects and attacks are not blocked by cover unless the 
+cover specifically states otherwise. Targets of Beam-shaped gravity techniques 
+benefit from being harder to aim at: Partial cover grants +10 to saves while 
+total obscurement grants advantage on saves. This does not apply to techniques 
+using Conical or Radial fields.
 
 ===== Gravity Techniques =====
 

--- a/CharacterCreation/Class-Specific Documentation/Gravity_Technician_Abilities.txt
+++ b/CharacterCreation/Class-Specific Documentation/Gravity_Technician_Abilities.txt
@@ -407,6 +407,7 @@ to be that shape for this purpose.
 == Sphere ==
 
 Prerequisite: None
+Type: Radial
 
 	The sphere shape affects all massive objects within range in every 
 direction.
@@ -414,6 +415,7 @@ direction.
 == Hemisphere ==
 
 Prerequisite: Sphere
+Type: Radial
 
 	The hemisphere shape affects all massive objects within range that are 
 within 90 degrees of the declared direction.
@@ -421,6 +423,7 @@ within 90 degrees of the declared direction.
 == Beam ==
 
 Prerequisite: Sphere
+Type: Beam
 
 	The beam shape affects all massive objects in a line up to the 
 Technique's range in length. If the line passes through opposite sides 
@@ -429,6 +432,7 @@ of a square, it affects objects in that square.
 == Cone ==
 
 Prerequisite: Hemisphere
+Type: Conical
 
 	The cone shape affects all massive objects within range that are within 
 a 45 degree cone.
@@ -436,6 +440,7 @@ a 45 degree cone.
 == Ring ==
 
 Prerequisites: Sphere
+Type: Radial
 
 	The ring shape affects all massive objects within range that occupy the 
 same plane.
@@ -443,6 +448,7 @@ same plane.
 == Sector ==
 
 Prerequisite: Ring
+Type: Conical
 
 	The sector shape affects all massive objects within range that occupy the 
 same plane and are within a 45 degree sector. A sector is a two-dimensional cone.
@@ -450,6 +456,7 @@ same plane and are within a 45 degree sector. A sector is a two-dimensional cone
 == (Adv) Double Beam ==
 
 Prerequisite: Beam
+Type: Beam
 
 	This advanced shape projects two Beams simultaneously. The beams must 
 be within 45 degrees of each other or exactly 180 degrees apart. Using this 
@@ -458,6 +465,7 @@ shape reduces the maximum range of a Technique by half.
 == (Adv) Multibeam ==
 
 Prerequisite: Double Beam, Level 16
+Type: Beam
 
 	This advanced shape projects arbitrarily many Beams, but any Technique 
 using this shape requires an additional Action of preparation to use. Using two 
@@ -467,6 +475,7 @@ range by a further 5 meters.
 == (Adv) Double Ring ==
 
 Prerequisite: Ring
+Type: Radial
 
 	This advanced shape projects two perpendicular rings. Anything caught in a 
 suqare where the two Rings intersect takes 50% more damage from a damaging technique, 
@@ -475,6 +484,7 @@ and any Save DC from the used Technique is increased by 50%.
 == (Adv) Triple Ring ==
 
 Prerequisite: Double Ring, Level 16
+Type: Radial
 
 	This advanced shape projects three perpendicular rings. Anything caught in a 
 suqare where two Rings intersect takes 50% more damage from a damaging technique, 
@@ -483,6 +493,7 @@ and any Save DC from the used Technique is increased by 50%.
 == (Adv) Cross Sector ==
 
 Prerequisite: Sector
+Type: Conical
 
 	This advanced shape projects two perpendicular sectors that intersect each 
 other's centers. Anything caught in a suqare where the two Sectors intersect takes 

--- a/CharacterCreation/Class-Specific Documentation/Gravity_Technician_Abilities.txt
+++ b/CharacterCreation/Class-Specific Documentation/Gravity_Technician_Abilities.txt
@@ -3,64 +3,34 @@ Gravity Technician Abilities
 ==============================
 
 A Note on Terminology:
-	In this document, the word "massive" is not meant to imply 
-largeness or heaviness. It means only that the referenced object 
-has mass, and is thus affected by gravity.
+	Where used in this class's documentation, the word "massive" is 
+not meant to imply largeness or heaviness. It means only that the 
+referenced object has mass, and is thus affected by gravity.
 
 == Gravity Technique Ranges ==
 
-	Standard range is given on the table below. When using a 
-Technique with Standard range, the Technician may set the maximum range 
-of effect any distance equal or lesser than the given value. Any effects 
-that take place at fractional range are determined based on the range used, 
-not the maximum range available.
+	Gravity Projectors have a maximum range at which they can exert 
+noticeable force. When using a Technique with Weapon range, the Technician 
+may set the maximum range of effect any distance equal or lesser than the 
+given value. Any effects that take place at fractional range, such as the 
+effects of Impeller Field, are determined based on the maximum range used, 
+not the maximum range possible.
 
 	Some techniques have Personal range, which means that they only 
 apply effects within the user's square except as otherwise stated.
 
-+-------+---------------+---------+
-| Level | Maximum Range | Save DC |
-+-------+---------------+---------+
-| 1     | 20m           | 42      |
-+-------+---------------+---------+
-| 2     | 25m           | 44      |
-+-------+---------------+---------+
-| 3     | 30m           | 46      |
-+-------+---------------+---------+
-| 4     | 33m           | 48      |
-+-------+---------------+---------+
-| 5     | 36m           | 50      |
-+-------+---------------+---------+
-| 6     | 39m           | 52      |
-+-------+---------------+---------+
-| 7     | 42m           | 54      |
-+-------+---------------+---------+
-| 8     | 45m           | 56      |
-+-------+---------------+---------+
-| 9     | 48m           | 58      |
-+-------+---------------+---------+
-| 10    | 51m           | 60      |
-+-------+---------------+---------+
-| 11    | 54m           | 62      |
-+-------+---------------+---------+
-| 12    | 57m           | 64      |
-+-------+---------------+---------+
-| 13    | 60m           | 66      |
-+-------+---------------+---------+
-| 14    | 63m           | 68      |
-+-------+---------------+---------+
-| 15    | 66m           | 70      |
-+-------+---------------+---------+
-| 16    | 69m           | 72      |
-+-------+---------------+---------+
-| 17    | 72m           | 74      |
-+-------+---------------+---------+
-| 18    | 75m           | 76      |
-+-------+---------------+---------+
-| 19    | 78m           | 78      |
-+-------+---------------+---------+
-| 20    | 81m           | 80      |
-+-------+---------------+---------+
+	For Techniques that allow targets to make a Save to mitigate 
+effects, the base DC is given by the Gravity Projector and may be modified 
+by microassembly cores or peripherals.
+
+	Techniques that require Channeling take 2 Actions to activate and 
+cost 2 Actions each subsequent turn that the ability is maintained. The 
+user may move and take other Actions while channeling, but cannot use 
+other Techniques and must maintain control of their gravity projector. A 
+GravTech who takes more than 80 damage in an Action must make a Will save 
+with DC equal to half the damage taken to maintain the technique; on failure 
+the channel stops. The user may stop the channel any time on their turn 
+as a Free Action.
 
 ===== Gravity Techniques =====
 
@@ -121,7 +91,7 @@ Within full range: 1m/Round
 Prerequisites: Pull
 
 Graviton Coat: 30
-Duration: 1 Action
+Duration: 2 Actions
 Range: Standard
 Save: Reflex
 Field Shapes: Beam
@@ -136,7 +106,7 @@ a Maneuver Check.
 Prerequisites: None
 
 Graviton Cost: 35
-Duration: 1 Action
+Duration: 2 Actions
 Range: Standard
 Save: See below
 Field Shapes: Beam, Ring, Sector
@@ -171,7 +141,7 @@ save halves the damage.
 Prerequisites: None
 
 Graviton Cost: 25
-Duration: 1 Action
+Duration: 2 Actions
 Range: Standard
 Save: Reflex
 Field Shapes: Sphere
@@ -204,7 +174,7 @@ Field Shapes: Sphere, Hemisphere, Cone, Ring, Sector
 Prerequisites: Level 6
 
 Graviton Cost: 45 Gravitons
-Duration: 1 Action
+Duration: 2 Actions
 Range: Standard
 Save: Shock
 Field Shapes: Sphere, Hemisphere, Cone, Ring, Sector
@@ -221,8 +191,8 @@ Within full range: 5m
 
 Prerequisites: Pull Pulse
 
-Graviton Coat: 
-Duration: 1 Action
+Graviton Cost: 
+Duration: 2 Actions
 Range: Standard
 Save: Shock
 Field Shapes: Sphere, Hemisphere, Cone, Ring, Sector
@@ -234,7 +204,7 @@ Field Shapes: Sphere, Hemisphere, Cone, Ring, Sector
 Prerequisites: Level 6
 
 Graviton Cost: 35
-Duration: 1 Action
+Duration: 2 Actions
 Range: Standard
 Save: See below
 Field Shapes: Beam
@@ -268,7 +238,7 @@ to 1 meter.
 Prerequisites: Gravity Sling, Level 6
 
 Graviton Coat: 
-Duration: 1 Action
+Duration: 2 Actions
 Range: Standard
 Save: Reflex
 Field Shapes: Sphere
@@ -288,7 +258,7 @@ trajectory is deflected by at leat 90 degrees.
 Prerequisites: Gravity Spike, Level 11
 
 Graviton Coat: 
-Duration: 1 Action
+Duration: 2 Actions
 Range: Standard
 Save: See below
 Field Shapes: Beam
@@ -300,7 +270,7 @@ Field Shapes: Beam
 Prerequisites: Tidal Shear, Level 11
 
 Graviton Coat: 
-Duration: 1 Action
+Duration: 2 Actions
 Range: Standard
 Save: See below
 Field Shapes: Beam, Ring, Sector
@@ -362,7 +332,7 @@ Field Shapes: Beam
 Prerequisites: Pull Pulse II, Level 16
 
 Graviton Coat: 
-Duration: 
+Duration: 2 Actions
 Range: Standard
 Save: Shock
 Field Shapes: Sphere, Hemisphere, Cone, Ring, Sector
@@ -385,7 +355,7 @@ least 180 degrees to attempt Stasis.
 Prerequisites: Gravity Bolt, Level 16
 
 Graviton Coat: 
-Duration: 1 Action
+Duration: 2 Actions
 Range: Standard
 Save: See below
 Field Shapes: Beam
@@ -397,7 +367,7 @@ Field Shapes: Beam
 Prerequisites: Tidal Tear, Level 16
 
 Graviton Coat: 
-Duration: 1 Action
+Duration: 2 Actions
 Range: Standard
 Save: See below
 Field Shapes: Beam, Ring, Sector
@@ -461,7 +431,7 @@ of a square, it affects objects in that square.
 Prerequisite: Hemisphere
 
 	The cone shape affects all massive objects within range that are within 
-45 degrees of the declared direction.
+a 45 degree cone.
 
 == Ring ==
 
@@ -475,7 +445,7 @@ same plane.
 Prerequisite: Ring
 
 	The sector shape affects all massive objects within range that occupy the 
-same plane and are within 45 degrees of the declared direction.
+same plane and are within a 45 degree sector. A sector is a two-dimensional cone.
 
 == (Adv) Double Beam ==
 

--- a/Items/04_07_Technician_Equipment
+++ b/Items/04_07_Technician_Equipment
@@ -60,3 +60,7 @@ Resource Generation (Short Rest): +30
 Beam Field Range: +5m
 Conical Field Range: +2m
 Radial Field Range: +0m
+
+== Mark I Field Control "Wobbler" Module ==
+
+Resistance DC: +10

--- a/Items/04_07_Technician_Equipment
+++ b/Items/04_07_Technician_Equipment
@@ -1,0 +1,62 @@
+==============================
+Gravity Projectors
+==============================
+
+===== Level 1 Availability =====
+
+== Mark I Reengineered Gravity Projector ==
+
+Beam Field Range: 25m
+Conical Field Range: 10m
+Radial Field Range: 30m
+Resistance DC: 40
+Price: 1750
+
+= Series I Reconditioned Gravity Projector ==
+
+Beam Field Range: 20m
+Conical Field Range: 15m
+Radial Field Range: 35m
+Resistance DC: 40
+Price: 1750
+
+==============================
+Particle Field Manipulators
+==============================
+
+	To be added with ParTech class.
+
+==============================
+Microassembly Core
+==============================
+
+===== Level 1 Availability =====
+
+== M1-01 Kepler Lake Microassembly Core ==
+
+Resource Storage: 100
+Resource Generation (Short Rest): 0
+Resource Generation (Long Rest): 100
+Hard Points: 1
+Resistance DC Increase: 0
+Price: 1000
+
+==============================
+Microassembly Peripherals
+==============================
+
+===== Level 1 Availability =====
+
+== Sustained Use Streamlining Module ==
+
+Resource Channel Cost: -1/Round
+
+== Field-expedient Graviton Production Catalyst ==
+
+Resource Generation (Short Rest): +30
+
+== Paramassive Projector Focusing Module ==
+
+Beam Field Range: +5m
+Conical Field Range: +2m
+Radial Field Range: +0m

--- a/Items/04_07_Technician_Equipment
+++ b/Items/04_07_Technician_Equipment
@@ -10,6 +10,8 @@ Beam Field Range: 25m
 Conical Field Range: 10m
 Radial Field Range: 30m
 Resistance DC: 40
+Reflex Modifier: -10
+Movement Speed Penalty: -1m
 Price: 1750
 
 = Series I Reconditioned Gravity Projector ==
@@ -18,6 +20,8 @@ Beam Field Range: 20m
 Conical Field Range: 15m
 Radial Field Range: 35m
 Resistance DC: 40
+Reflex Modifier: -10
+Movement Speed Penalty: -1m
 Price: 1750
 
 ==============================


### PR DESCRIPTION
Addressing your concerns about Conical Field ranges. May have scope crept a lot. Send help. Also look at the things!

Field shape ranges divided into 3 categories, now owned by Projector items instead of level. Save DCs moved there too.
First item entries for Cores and Peripherals. They give "Resource" instead of gravitons because **[REDACTED]** will also use them to generate **[REDACTED]**!