### PR TITLE
added below the belt feat

### DIFF
--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -56,6 +56,22 @@ Prerequisites:
     Any damage dealt to an unaware opponent from behind deals an additional 
 10 + (Lvl * 2) Base damage.
 
+== Below the Belt ==
+
+Prerequisites:
+
+*  Luck 4
+*  Dex 6
+
+    You've got enough luck, courage, and precision to shoot in a general 
+direction without taking the time to aim properly. Your firearms teacher would
+be very disappointed at the lack of form, but if you don't get out of this 
+sticky situation then you won't get to hear from him anyway.
+
+    The penalty for hip firing with a CQB weapon is reduced by 1 in your R1 
+range bracket. For more information on hip firing, see the "Hip Firing" section
+of the Shooting rules in combat rules.
+
 == Bulltrue ==
 Prerequisites: 
 

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -70,7 +70,7 @@ sticky situation then you won't get to hear from him anyway.
 
     The penalty for hip firing with a CQB weapon is reduced by 1 in your R1 
 range bracket. For more information on hip firing, see the "Hip Firing" section
-of the Shooting rules in combat rules.
+of the Shooting Rules document in the Combat Rules directory.
 
 == Bulltrue ==
 Prerequisites: 

--- a/CharacterCreation/03_Feats.txt
+++ b/CharacterCreation/03_Feats.txt
@@ -70,7 +70,7 @@ sticky situation then you won't get to hear from him anyway.
 
     The penalty for hip firing with a CQB weapon is reduced by 1 in your R1 
 range bracket. For more information on hip firing, see the "Hip Firing" section
-of the Shooting rules in combat rules.
+of the Shooting Rules document in Combat Rules directory.
 
 == Bulltrue ==
 Prerequisites: 


### PR DESCRIPTION
	modified:   03_Feats.txt
	modified:   ../Combat Rules/2_Shooting.txt

A reduction from -3 to -2 might not sound like a big deal, but it can be combined with several attachments to get fairly scary hipfire synergies. The range limit on it I think balances that out well, and the CQB qualifier means you can't hip-fire well with an assault rifle, chain gun, or rocket launcher. Looking for sanity check and push back. Issue #507 